### PR TITLE
Update routed action to have typed settings

### DIFF
--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -418,7 +418,7 @@ describe("StreamDeckClient", () => {
 
 		// Assert.
 		expect(listener).toHaveBeenCalledTimes(1);
-		expect(listener).toHaveBeenCalledWith<[PropertyInspectorDidAppearEvent]>({
+		expect(listener).toHaveBeenCalledWith<[PropertyInspectorDidAppearEvent<never>]>({
 			action: new Action(client, action, context),
 			deviceId: device,
 			type: "propertyInspectorDidAppear"
@@ -440,7 +440,7 @@ describe("StreamDeckClient", () => {
 
 		// Assert.
 		expect(listener).toHaveBeenCalledTimes(1);
-		expect(listener).toHaveBeenCalledWith<[PropertyInspectorDidDisappearEvent]>({
+		expect(listener).toHaveBeenCalledWith<[PropertyInspectorDidDisappearEvent<never>]>({
 			action: new Action(client, action, context),
 			deviceId: device,
 			type: "propertyInspectorDidDisappear"
@@ -462,7 +462,7 @@ describe("StreamDeckClient", () => {
 
 		// Assert.
 		expect(listener).toHaveBeenCalledTimes(1);
-		expect(listener).toHaveBeenCalledWith<[SendToPluginEvent<mockEvents.Settings>]>({
+		expect(listener).toHaveBeenCalledWith<[SendToPluginEvent<mockEvents.Settings, never>]>({
 			action: new Action(client, action, context),
 			payload,
 			type: "sendToPlugin"

--- a/src/actions/__tests__/action.test.ts
+++ b/src/actions/__tests__/action.test.ts
@@ -33,10 +33,10 @@ describe("Action", () => {
 	it("Can getSettings", async () => {
 		// Arrange.
 		const { connection, client } = getMockedClient();
-		const action = new Action(client, "com.elgato.test.one", "ABC123");
+		const action = new Action<mockEvents.Settings>(client, "com.elgato.test.one", "ABC123");
 
 		// Act (Command).
-		const settings = action.getSettings<mockEvents.Settings>();
+		const settings = action.getSettings();
 
 		// Assert (Command).
 		expect(connection.send).toHaveBeenCalledTimes(1);
@@ -153,7 +153,7 @@ describe("Action", () => {
 	it("Sends setSettings", async () => {
 		// Arrange.
 		const { connection, client } = getMockedClient();
-		const action = new Action(client, "com.elgato.test.one", "ABC123");
+		const action = new Action<mockEvents.Settings>(client, "com.elgato.test.one", "ABC123");
 
 		// Act.
 		await action.setSettings({

--- a/src/actions/__tests__/actions-controller.test.ts
+++ b/src/actions/__tests__/actions-controller.test.ts
@@ -1,7 +1,7 @@
 import { getMockedClient } from "../../../tests/__mocks__/client";
 import { manifest as mockManifest } from "../../__mocks__/manifest";
 import { ActionsController } from "../actions-controller";
-import { Route } from "../route";
+import { addRoute } from "../route";
 import { SingletonAction } from "../singleton-action";
 
 jest.mock("../singleton-action");
@@ -35,9 +35,8 @@ describe("ActionsController", () => {
 		expect(createScopeSpy).toHaveBeenCalledWith("ActionsController");
 	});
 
-	it("Adds valid routes", () => {
+	it("Configures route", () => {
 		// Arrange.
-		const mockedRoute = Route as jest.MockedClass<typeof Route>;
 		const { logger, client } = getMockedClient();
 		const action: SingletonAction = {
 			manifestId
@@ -48,8 +47,8 @@ describe("ActionsController", () => {
 		actions.registerAction(action);
 
 		// Assert.
-		expect(mockedRoute.mock.instances).toHaveLength(1);
-		expect(mockedRoute.mock.calls[0]).toEqual([client, action]);
+		expect(addRoute).toHaveBeenCalledTimes(1);
+		expect(addRoute).toHaveBeenCalledWith(client, action);
 	});
 
 	it("Warns when action does not exist in manifest", () => {

--- a/src/actions/__tests__/route.test.ts
+++ b/src/actions/__tests__/route.test.ts
@@ -16,7 +16,7 @@ import {
 	WillDisappearEvent
 } from "../../events";
 import { Action } from "../action";
-import { Route } from "../route";
+import { addRoute } from "../route";
 import type { SingletonAction } from "../singleton-action";
 
 jest.mock("../singleton-action");
@@ -34,7 +34,7 @@ describe("Route", () => {
 		};
 
 		// Act, assert.
-		expect(() => new Route(client, action)).toThrow("The action's manifestId cannot be undefined.");
+		expect(() => addRoute(client, action)).toThrow("The action's manifestId cannot be undefined.");
 	});
 
 	it("Routes onDialDown", () => {
@@ -46,7 +46,7 @@ describe("Route", () => {
 		};
 
 		// Act.
-		new Route(client, action);
+		addRoute(client, action);
 
 		const { device, payload, context } = connection.__emit({
 			...mockEvents.dialDown,
@@ -74,7 +74,7 @@ describe("Route", () => {
 		};
 
 		// Act.
-		new Route(client, action);
+		addRoute(client, action);
 
 		const { device, payload, context } = connection.__emit({
 			...mockEvents.dialRotate,
@@ -103,7 +103,7 @@ describe("Route", () => {
 		};
 
 		// Act.
-		new Route(client, action);
+		addRoute(client, action);
 
 		const { device, payload, context } = connection.__emit({
 			...mockEvents.dialUp,
@@ -132,7 +132,7 @@ describe("Route", () => {
 		};
 
 		// Act.
-		new Route(client, action);
+		addRoute(client, action);
 
 		const { device, payload, context } = connection.__emit({
 			...mockEvents.didReceiveSettings,
@@ -161,7 +161,7 @@ describe("Route", () => {
 		};
 
 		// Act.
-		new Route(client, action);
+		addRoute(client, action);
 
 		const { device, payload, context } = connection.__emit({
 			...mockEvents.keyDown,
@@ -190,7 +190,7 @@ describe("Route", () => {
 		};
 
 		// Act.
-		new Route(client, action);
+		addRoute(client, action);
 
 		const { device, payload, context } = connection.__emit({
 			...mockEvents.keyUp,
@@ -219,7 +219,7 @@ describe("Route", () => {
 		};
 
 		// Act.
-		new Route(client, action);
+		addRoute(client, action);
 
 		const { device, context } = connection.__emit({
 			...mockEvents.propertyInspectorDidAppear,
@@ -231,7 +231,7 @@ describe("Route", () => {
 		// Assert.
 		expect(action.onPropertyInspectorDidAppear).toHaveBeenCalledTimes(1);
 		expect((action.onPropertyInspectorDidAppear as jest.Mock).mock.contexts[0]).toStrictEqual(action);
-		expect(action.onPropertyInspectorDidAppear).toHaveBeenCalledWith<[PropertyInspectorDidAppearEvent]>({
+		expect(action.onPropertyInspectorDidAppear).toHaveBeenCalledWith<[PropertyInspectorDidAppearEvent<never>]>({
 			action: new Action(client, manifestId, context),
 			deviceId: device,
 			type: "propertyInspectorDidAppear"
@@ -247,7 +247,7 @@ describe("Route", () => {
 		};
 
 		// Act.
-		new Route(client, action);
+		addRoute(client, action);
 
 		const { device, context } = connection.__emit({
 			...mockEvents.propertyInspectorDidDisappear,
@@ -259,7 +259,7 @@ describe("Route", () => {
 		// Assert.
 		expect(action.onPropertyInspectorDidDisappear).toHaveBeenCalledTimes(1);
 		expect((action.onPropertyInspectorDidDisappear as jest.Mock).mock.contexts[0]).toStrictEqual(action);
-		expect(action.onPropertyInspectorDidDisappear).toHaveBeenCalledWith<[PropertyInspectorDidDisappearEvent]>({
+		expect(action.onPropertyInspectorDidDisappear).toHaveBeenCalledWith<[PropertyInspectorDidDisappearEvent<never>]>({
 			action: new Action(client, manifestId, context),
 			deviceId: device,
 			type: "propertyInspectorDidDisappear"
@@ -275,7 +275,7 @@ describe("Route", () => {
 		};
 
 		// Act.
-		new Route(client, action);
+		addRoute(client, action);
 
 		const { payload, context } = connection.__emit({
 			...mockEvents.sendToPlugin,
@@ -287,7 +287,7 @@ describe("Route", () => {
 		// Assert.
 		expect(action.onSendToPlugin).toHaveBeenCalledTimes(1);
 		expect((action.onSendToPlugin as jest.Mock).mock.contexts[0]).toStrictEqual(action);
-		expect(action.onSendToPlugin).toHaveBeenCalledWith<[SendToPluginEvent<mockEvents.Settings>]>({
+		expect(action.onSendToPlugin).toHaveBeenCalledWith<[SendToPluginEvent<mockEvents.Settings, never>]>({
 			action: new Action(client, manifestId, context),
 			payload,
 			type: "sendToPlugin"
@@ -303,7 +303,7 @@ describe("Route", () => {
 		};
 
 		// Act.
-		new Route(client, action);
+		addRoute(client, action);
 
 		const { device, payload, context } = connection.__emit({
 			...mockEvents.titleParametersDidChange,
@@ -332,7 +332,7 @@ describe("Route", () => {
 		};
 
 		// Act.
-		new Route(client, action);
+		addRoute(client, action);
 
 		const { device, payload, context } = connection.__emit({
 			...mockEvents.touchTap,
@@ -361,7 +361,7 @@ describe("Route", () => {
 		};
 
 		// Act.
-		new Route(client, action);
+		addRoute(client, action);
 
 		const { device, payload, context } = connection.__emit({
 			...mockEvents.willAppear,
@@ -390,7 +390,7 @@ describe("Route", () => {
 		};
 
 		// Act.
-		new Route(client, action);
+		addRoute(client, action);
 
 		const { device, payload, context } = connection.__emit({
 			...mockEvents.willDisappear,
@@ -416,7 +416,7 @@ describe("Route", () => {
 		const onSpy = jest.spyOn(connection, "on");
 
 		// Act.
-		new Route(client, { manifestId });
+		addRoute(client, { manifestId });
 
 		// Assert.
 		expect(onSpy).not.toHaveBeenCalled();

--- a/src/actions/action.ts
+++ b/src/actions/action.ts
@@ -1,4 +1,4 @@
-import type { Settings, StreamDeckClient } from "../client";
+import type { StreamDeckClient } from "../client";
 import { SetTriggerDescription } from "../connectivity/commands";
 import { State } from "../connectivity/events";
 import { FeedbackPayload } from "../connectivity/layouts";
@@ -8,7 +8,7 @@ import type { SingletonAction } from "./singleton-action";
 /**
  * Provides a contextualized instance of an {@link Action}, allowing for direct communication with the Stream Deck.
  */
-export class Action {
+export class Action<TSettings> {
 	/**
 	 * Initializes a new instance of the {@see Action} class.
 	 * @param client The Stream Deck client.
@@ -22,7 +22,7 @@ export class Action {
 	 * with {@link Action.setSettings}.
 	 * @returns Promise containing the action instance's settings.
 	 */
-	public getSettings<T = unknown>(): Promise<Partial<T>> {
+	public getSettings<T = TSettings>(): Promise<Partial<T>> {
 		return this.client.getSettings<T>(this.id);
 	}
 
@@ -118,12 +118,8 @@ export class Action {
 	 * Sets the {@link settings} associated with this action instance. Use in conjunction with {@link Action.getSettings}.
 	 * @param settings Settings to persist.
 	 * @returns `Promise` resolved when the {@link settings} are sent to Stream Deck.
-	 * @example
-	 * action.setSettings({
-	 *   name: "Elgato"
-	 * })
 	 */
-	public setSettings<T>(settings: Settings<T>): Promise<void> {
+	public setSettings(settings: TSettings): Promise<void> {
 		return this.client.setSettings(this.id, settings);
 	}
 

--- a/src/actions/actions-controller.ts
+++ b/src/actions/actions-controller.ts
@@ -1,7 +1,7 @@
 import { StreamDeckClient } from "../client";
 import { Logger } from "../logging";
 import { Manifest } from "../manifest";
-import { Route } from "./route";
+import { addRoute } from "./route";
 import { SingletonAction } from "./singleton-action";
 
 /**
@@ -12,11 +12,6 @@ export class ActionsController {
 	 * Logger scoped to this class.
 	 */
 	private readonly logger: Logger;
-
-	/**
-	 * Collection of registered routes.
-	 */
-	private readonly routes: Route[] = [];
 
 	/**
 	 * Initializes a new instance of the {@link ActionsController} class.
@@ -43,7 +38,7 @@ export class ActionsController {
 	 */
 	public registerAction<TAction extends SingletonAction<TSettings>, TSettings = unknown>(action: TAction) {
 		if (action.manifestId !== undefined && this.manifest.Actions.find((a) => a.UUID === action.manifestId)) {
-			this.routes.push(new Route(this.client, action));
+			addRoute(this.client, action);
 		} else {
 			this.logger.warn(`Failed to route action: manifestId (UUID) ${action.manifestId} was not found in the manifest.`);
 		}

--- a/src/actions/singleton-action.ts
+++ b/src/actions/singleton-action.ts
@@ -64,19 +64,19 @@ export class SingletonAction<TSettings = unknown> {
 	 * Occurs when the property inspector associated with the action becomes visible, i.e. the user selected an action in the Stream Deck application. Also see {@link StreamDeckClient.onPropertyInspectorDidDisappear}.
 	 * @param listener Function to be invoked when the event occurs.
 	 */
-	public onPropertyInspectorDidAppear?(ev: PropertyInspectorDidAppearEvent): void;
+	public onPropertyInspectorDidAppear?(ev: PropertyInspectorDidAppearEvent<TSettings>): void;
 
 	/**
 	 * Occurs when the property inspector associated with the action becomes invisible, i.e. the user unselected the action in the Stream Deck application. Also see {@link StreamDeckClient.onPropertyInspectorDidAppear}.
 	 * @param listener Function to be invoked when the event occurs.
 	 */
-	public onPropertyInspectorDidDisappear?(ev: PropertyInspectorDidDisappearEvent): void;
+	public onPropertyInspectorDidDisappear?(ev: PropertyInspectorDidDisappearEvent<TSettings>): void;
 
 	/**
 	 * Occurs when a message was sent to the plugin _from_ the property inspector. The plugin can also send messages _to_ the property inspector using {@link StreamDeckClient.sendToPropertyInspector}.
 	 * @param listener Function to be invoked when the event occurs.
 	 */
-	public onSendToPlugin?(ev: SendToPluginEvent<object>): void;
+	public onSendToPlugin?(ev: SendToPluginEvent<object, TSettings>): void;
 
 	/**
 	 * Occurs when the user updates an action's title settings in the Stream Deck application. Also see {@link StreamDeckClient.setTitle}.

--- a/src/client.ts
+++ b/src/client.ts
@@ -190,24 +190,28 @@ export class StreamDeckClient {
 	 * Occurs when the property inspector associated with the action becomes visible, i.e. the user selected an action in the Stream Deck application. Also see {@link StreamDeckClient.onPropertyInspectorDidDisappear}.
 	 * @param listener Function to be invoked when the event occurs.
 	 */
-	public onPropertyInspectorDidAppear(listener: (ev: PropertyInspectorDidAppearEvent) => void): void {
-		this.connection.on("propertyInspectorDidAppear", (ev: events.PropertyInspectorDidAppear) => listener(new ActionWithoutPayloadEvent(this, ev)));
+	public onPropertyInspectorDidAppear<TSettings = unknown>(listener: (ev: PropertyInspectorDidAppearEvent<TSettings>) => void): void {
+		this.connection.on("propertyInspectorDidAppear", (ev: events.PropertyInspectorDidAppear) =>
+			listener(new ActionWithoutPayloadEvent<events.PropertyInspectorDidAppear, TSettings>(this, ev))
+		);
 	}
 
 	/**
 	 * Occurs when the property inspector associated with the action becomes invisible, i.e. the user unselected the action in the Stream Deck application. Also see {@link StreamDeckClient.onPropertyInspectorDidAppear}.
 	 * @param listener Function to be invoked when the event occurs.
 	 */
-	public onPropertyInspectorDidDisappear(listener: (ev: PropertyInspectorDidDisappearEvent) => void): void {
-		this.connection.on("propertyInspectorDidDisappear", (ev: events.PropertyInspectorDidDisappear) => listener(new ActionWithoutPayloadEvent(this, ev)));
+	public onPropertyInspectorDidDisappear<TSettings = unknown>(listener: (ev: PropertyInspectorDidDisappearEvent<TSettings>) => void): void {
+		this.connection.on("propertyInspectorDidDisappear", (ev: events.PropertyInspectorDidDisappear) =>
+			listener(new ActionWithoutPayloadEvent<events.PropertyInspectorDidDisappear, TSettings>(this, ev))
+		);
 	}
 
 	/**
 	 * Occurs when a message was sent to the plugin _from_ the property inspector. The plugin can also send messages _to_ the property inspector using {@link StreamDeckClient.sendToPropertyInspector}.
 	 * @param listener Function to be invoked when the event occurs.
 	 */
-	public onSendToPlugin<TPayload extends object>(listener: (ev: SendToPluginEvent<TPayload>) => void): void {
-		this.connection.on("sendToPlugin", (ev: events.SendToPlugin<TPayload>) => listener(new SendToPluginEvent(this, ev)));
+	public onSendToPlugin<TPayload extends object, TSettings = unknown>(listener: (ev: SendToPluginEvent<TPayload, TSettings>) => void): void {
+		this.connection.on("sendToPlugin", (ev: events.SendToPlugin<TPayload>) => listener(new SendToPluginEvent<TPayload, TSettings>(this, ev)));
 	}
 
 	/**
@@ -371,7 +375,7 @@ export class StreamDeckClient {
 	 *   connectedDate: new Date()
 	 * })
 	 */
-	public setGlobalSettings<T>(settings: Settings<T>): Promise<void> {
+	public setGlobalSettings<T>(settings: T): Promise<void> {
 		return this.connection.send({
 			event: "setGlobalSettings",
 			context: this.connection.registrationParameters.pluginUUID,
@@ -412,7 +416,7 @@ export class StreamDeckClient {
 	 *   name: "Elgato"
 	 * })
 	 */
-	public setSettings<T>(context: string, settings: Settings<T>): Promise<void> {
+	public setSettings<T>(context: string, settings: T): Promise<void> {
 		return this.connection.send({
 			event: "setSettings",
 			context,
@@ -517,12 +521,3 @@ export class StreamDeckClient {
 		});
 	}
 }
-
-/**
- * Defines the object structure of settings that can be persisted within Stream Deck. Settings are persisted as JSON objects, and can only include primitive types, and objects.
- */
-export type Settings<T> = {
-	[K in keyof T]: T[K] extends (...args: unknown[]) => unknown ? never : unknown;
-}[keyof T] extends never
-	? never
-	: T;

--- a/src/events/action-event.ts
+++ b/src/events/action-event.ts
@@ -6,11 +6,11 @@ import { Event } from "./event";
 /**
  * Provides information for an event relating to an action.
  */
-export class ActionWithoutPayloadEvent<T extends Extract<events.Event, events.ActionIdentifier & events.DeviceIdentifier>> extends Event<T> {
+export class ActionWithoutPayloadEvent<T extends Extract<events.Event, events.ActionIdentifier & events.DeviceIdentifier>, TSettings> extends Event<T> {
 	/**
 	 * The action that raised the event.
 	 */
-	public readonly action: Action;
+	public readonly action: Action<TSettings>;
 
 	/**
 	 * Device identifier the action is associated with.
@@ -25,7 +25,7 @@ export class ActionWithoutPayloadEvent<T extends Extract<events.Event, events.Ac
 	constructor(client: StreamDeckClient, source: T) {
 		super(source);
 
-		this.action = new Action(client, source.action, source.context);
+		this.action = new Action<TSettings>(client, source.action, source.context);
 		this.deviceId = source.device;
 	}
 }
@@ -33,7 +33,10 @@ export class ActionWithoutPayloadEvent<T extends Extract<events.Event, events.Ac
 /**
  * Provides information for an event relating to an action.
  */
-export class ActionEvent<T extends Extract<events.Event, events.ActionIdentifier & events.DeviceIdentifier> & PayloadEvent<T>> extends ActionWithoutPayloadEvent<T> {
+export class ActionEvent<T extends Extract<events.Event, events.ActionIdentifier & events.DeviceIdentifier> & PayloadEvent<T>, TSettings> extends ActionWithoutPayloadEvent<
+	T,
+	TSettings
+> {
 	/**
 	 * Provides additional information about the event that occurred, e.g. how many `ticks` the dial was rotated, the current `state` of the action, etc.
 	 */

--- a/src/events/index.ts
+++ b/src/events/index.ts
@@ -32,47 +32,47 @@ export type DeviceDidDisconnectEvent = DeviceEvent<events.DeviceDidDisconnect, D
 /**
  * Event information received from Stream Deck as part of the {@link events.DialDown} event.
  */
-export type DialDownEvent<TSettings> = ActionEvent<events.DialDown<TSettings>>;
+export type DialDownEvent<TSettings> = ActionEvent<events.DialDown<TSettings>, TSettings>;
 
 /**
  * Event information received from Stream Deck as part of the {@link events.DialRotate} event.
  */
-export type DialRotateEvent<TSettings> = ActionEvent<events.DialRotate<TSettings>>;
+export type DialRotateEvent<TSettings> = ActionEvent<events.DialRotate<TSettings>, TSettings>;
 
 /**
  * Event information received from Stream Deck as part of the {@link events.DialUp} event.
  */
-export type DialUpEvent<TSettings> = ActionEvent<events.DialUp<TSettings>>;
+export type DialUpEvent<TSettings> = ActionEvent<events.DialUp<TSettings>, TSettings>;
 
 /**
  * Event information received from Stream Deck as part of the {@link events.DidReceiveSettings} event.
  */
-export type DidReceiveSettingsEvent<TSettings> = ActionEvent<events.DidReceiveSettings<TSettings>>;
+export type DidReceiveSettingsEvent<TSettings> = ActionEvent<events.DidReceiveSettings<TSettings>, TSettings>;
 
 /**
  * Event information received from Stream Deck as part of the {@link events.KeyDown} event.
  */
-export type KeyDownEvent<TSettings> = ActionEvent<events.KeyDown<TSettings>>;
+export type KeyDownEvent<TSettings> = ActionEvent<events.KeyDown<TSettings>, TSettings>;
 
 /**
  * Event information received from Stream Deck as part of the {@link events.KeyUp} event.
  */
-export type KeyUpEvent<TSettings> = ActionEvent<events.KeyUp<TSettings>>;
+export type KeyUpEvent<TSettings> = ActionEvent<events.KeyUp<TSettings>, TSettings>;
 
 /**
  * Event information received from Stream Deck as part of the {@link events.PropertyInspectorDidAppear} event.
  */
-export type PropertyInspectorDidAppearEvent = ActionWithoutPayloadEvent<events.PropertyInspectorDidAppear>;
+export type PropertyInspectorDidAppearEvent<TSettings> = ActionWithoutPayloadEvent<events.PropertyInspectorDidAppear, TSettings>;
 
 /**
  * Event information received from Stream Deck as part of the {@link events.PropertyInspectorDidDisappear} event.
  */
-export type PropertyInspectorDidDisappearEvent = ActionWithoutPayloadEvent<events.PropertyInspectorDidDisappear>;
+export type PropertyInspectorDidDisappearEvent<TSettings> = ActionWithoutPayloadEvent<events.PropertyInspectorDidDisappear, TSettings>;
 
 /**
  * Event information received from Stream Deck as part of the {@link events.TitleParametersDidChange} event.
  */
-export type TitleParametersDidChangeEvent<TSettings> = ActionEvent<events.TitleParametersDidChange<TSettings>>;
+export type TitleParametersDidChangeEvent<TSettings> = ActionEvent<events.TitleParametersDidChange<TSettings>, TSettings>;
 
 /**
  * Event information receives from Streak Deck as part of the {@link events.SystemDidWakeUp} event.
@@ -82,14 +82,14 @@ export type SystemDidWakeUpEvent = Event<events.SystemDidWakeUp>;
 /**
  * Event information received from Stream Deck as part of the {@link events.TouchTap} event.
  */
-export type TouchTapEvent<TSettings> = ActionEvent<events.TouchTap<TSettings>>;
+export type TouchTapEvent<TSettings> = ActionEvent<events.TouchTap<TSettings>, TSettings>;
 
 /**
  * Event information received from Stream Deck as part of the {@link events.WillAppear} event.
  */
-export type WillAppearEvent<TSettings> = ActionEvent<events.WillAppear<TSettings>>;
+export type WillAppearEvent<TSettings> = ActionEvent<events.WillAppear<TSettings>, TSettings>;
 
 /**
  * Event information received from Stream Deck as part of the {@link events.WillDisappear} event.
  */
-export type WillDisappearEvent<TSettings> = ActionEvent<events.WillDisappear<TSettings>>;
+export type WillDisappearEvent<TSettings> = ActionEvent<events.WillDisappear<TSettings>, TSettings>;

--- a/src/events/send-to-plugin-event.ts
+++ b/src/events/send-to-plugin-event.ts
@@ -6,11 +6,11 @@ import { Event } from "./event";
 /**
  * Provides information for an event trigger by a message being sent to the plugin, from the property inspector.
  */
-export class SendToPluginEvent<TPayload extends object> extends Event<SendToPlugin<TPayload>> {
+export class SendToPluginEvent<TPayload extends object, TSettings> extends Event<SendToPlugin<TPayload>> {
 	/**
 	 * The action that raised the event.
 	 */
-	public readonly action: Action;
+	public readonly action: Action<TSettings>;
 
 	/**
 	 * Payload sent from the property inspector.


### PR DESCRIPTION
- Update routed events so that `ev.action` contains typed methods when dealing with settings, e.g. `setSettings` and `getSettings`.
- Refactor `Route` class to be a single `addRoute` function.