### PR TITLE
Update i18n provider to read existing manifest

### DIFF
--- a/src/__tests__/stream-deck.test.ts
+++ b/src/__tests__/stream-deck.test.ts
@@ -152,7 +152,7 @@ describe("StreamDeck", () => {
 
 			const { _registrationParameters, logger } = streamDeck;
 			expect(I18nProvider).toHaveBeenCalledTimes(1);
-			expect(I18nProvider).toHaveBeenCalledWith(_registrationParameters.info.application.language, logger);
+			expect(I18nProvider).toHaveBeenCalledWith(_registrationParameters.info.application.language, getManifest(), logger);
 		});
 
 		/**
@@ -279,7 +279,7 @@ describe("StreamDeck", () => {
 			expect(getDevices).toHaveBeenCalledTimes(0);
 			expect(I18nProvider).toHaveBeenCalledTimes(1);
 			expect(createLogger).toHaveBeenCalledTimes(1);
-			expect(getManifest).toHaveBeenCalledTimes(0);
+			expect(getManifest).toHaveBeenCalledTimes(1);
 			expect(StreamDeckClient).toHaveBeenCalledTimes(0);
 			expect(StreamDeckConnection).toHaveBeenCalledTimes(0);
 			expect(RegistrationParameters).toHaveBeenCalledTimes(1);

--- a/src/stream-deck.ts
+++ b/src/stream-deck.ts
@@ -85,7 +85,7 @@ export class StreamDeck {
 	 * @returns The {@link I18nProvider}.
 	 */
 	public get i18n(): I18nProvider {
-		return this._i18n || (this._i18n = new I18nProvider(this.registrationParameters.info.application.language, this.logger));
+		return this._i18n || (this._i18n = new I18nProvider(this.registrationParameters.info.application.language, this.manifest, this.logger));
 	}
 
 	/**


### PR DESCRIPTION
The `I18nProvider` was manually loading the manifest file independently of the existing `getManifest` function. This refactors the `I18nProvider` to accept an existing manifest as part of it's construction, and prevents us loading the manifest twice.