### PR TITLE
feat: add range to bar and gbar layout elements

### DIFF
--- a/schemas/layout.json
+++ b/schemas/layout.json
@@ -102,6 +102,28 @@
 										],
 										"markdownDescription": "Width of the border around the bar, as a whole number. Default is `2`."
 									},
+									"range": {
+										"type": "object",
+										"properties": {
+											"min": {
+												"type": "number",
+												"description": "Minimum value of the bar.",
+												"markdownDescription": "Minimum value of the bar."
+											},
+											"max": {
+												"type": "number",
+												"description": "Maximum value of the bar",
+												"markdownDescription": "Maximum value of the bar"
+											}
+										},
+										"required": [
+											"min",
+											"max"
+										],
+										"additionalProperties": false,
+										"description": "Defines the range of the value the bar represents, e.g. 0-20, 0-100, etc.",
+										"markdownDescription": "Defines the range of the value the bar represents, e.g. 0-20, 0-100, etc."
+									},
 									"subtype": {
 										"$ref": "#/definitions/BarSubType",
 										"description": "Sub-type used to determine the type of bar to render. Default is  {@link  BarSubType.Groove } .",
@@ -252,6 +274,28 @@
 											2
 										],
 										"markdownDescription": "Width of the border around the bar, as a whole number. Default is `2`."
+									},
+									"range": {
+										"type": "object",
+										"properties": {
+											"min": {
+												"type": "number",
+												"description": "Minimum value of the bar.",
+												"markdownDescription": "Minimum value of the bar."
+											},
+											"max": {
+												"type": "number",
+												"description": "Maximum value of the bar",
+												"markdownDescription": "Maximum value of the bar"
+											}
+										},
+										"required": [
+											"min",
+											"max"
+										],
+										"additionalProperties": false,
+										"description": "Defines the range of the value the bar represents, e.g. 0-20, 0-100, etc.",
+										"markdownDescription": "Defines the range of the value the bar represents, e.g. 0-20, 0-100, etc."
 									},
 									"subtype": {
 										"$ref": "#/definitions/BarSubType",

--- a/schemas/manifest.json
+++ b/schemas/manifest.json
@@ -497,9 +497,7 @@
 				"Description",
 				"Icon",
 				"Name",
-				"Nodejs",
 				"OS",
-				"Profiles",
 				"SDKVersion",
 				"Software",
 				"Version"
@@ -520,8 +518,8 @@
 				6,
 				7
 			],
-			"description": "Stream Deck devices.",
-			"markdownDescription": "Stream Deck devices."
+			"description": "Stream Deck device types.",
+			"markdownDescription": "Stream Deck device types."
 		}
 	}
 }

--- a/scripts/generate-schemas.ts
+++ b/scripts/generate-schemas.ts
@@ -6,6 +6,7 @@ import { createGenerator, Schema } from "ts-json-schema-generator";
 // Create a generator so we're able to produce multiple schemas.
 const generator = createGenerator({
 	path: path.join(__dirname, "../src/index.ts"),
+	skipTypeCheck: true,
 	tsconfig: path.join(__dirname, "../tsconfig.json")
 });
 

--- a/src/connectivity/layouts.ts
+++ b/src/connectivity/layouts.ts
@@ -138,6 +138,21 @@ export type Bar = LayoutItem & {
 	border_w?: number;
 
 	/**
+	 * Defines the range of the value the bar represents, e.g. 0-20, 0-100, etc.
+	 */
+	range?: {
+		/**
+		 * Minimum value of the bar.
+		 */
+		min: number;
+
+		/**
+		 * Maximum value of the bar
+		 */
+		max: number;
+	};
+
+	/**
 	 * Sub-type used to determine the type of bar to render. Default is {@link BarSubType.Groove}.
 	 */
 	subtype?: BarSubType;


### PR DESCRIPTION
- Adds `range.min` and `range.max` to `bar` and `gbar` layout elements.
- Updates supporting JSON schemas.