### PR TITLE
refactor(!): add streamDeck.system namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 ### Breaking Changes
 
--   ♻️ Add `system` namespace; the following have been relocated from `streamDeck.client` to `streamDeck.system`:
+-   ✨ Add `system` namespace; the following have been relocated from `streamDeck.client` to `streamDeck.system`:
     -   `onApplicationDidLaunch`
     -   `onApplicationDidTerminate`
     -   `onSystemDidWakeUp`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@
 
 # Change Log
 
+## 0.2.0 (Pending)
+
+### Breaking Changes
+
+-   ♻️ Add `system` namespace; the following have been relocated from `streamDeck.client` to `streamDeck.system`:
+    -   `onApplicationDidLaunch`
+    -   `onApplicationDidTerminate`
+    -   `onSystemDidWakeUp`
+    -   `openUrl`
+
+### New
+
 ## 0.1.0
 
 ### New

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -5,7 +5,6 @@ import * as mockEvents from "../connectivity/__mocks__/events";
 import {
 	GetGlobalSettings,
 	GetSettings,
-	OpenUrl,
 	SendToPropertyInspector,
 	SetFeedback,
 	SetFeedbackLayout,
@@ -23,8 +22,6 @@ import { StreamDeckConnection } from "../connectivity/connection";
 import { Target } from "../connectivity/target";
 import { Device } from "../devices";
 import {
-	ApplicationDidLaunchEvent,
-	ApplicationDidTerminateEvent,
 	DeviceDidConnectEvent,
 	DeviceDidDisconnectEvent,
 	DialDownEvent,
@@ -37,7 +34,6 @@ import {
 	PropertyInspectorDidAppearEvent,
 	PropertyInspectorDidDisappearEvent,
 	SendToPluginEvent,
-	SystemDidWakeUpEvent,
 	TitleParametersDidChangeEvent,
 	TouchTapEvent,
 	WillAppearEvent,
@@ -108,52 +104,6 @@ describe("StreamDeckClient", () => {
 		// Assert (Event).
 		expect(await settings).toEqual<mockEvents.Settings>({
 			name: "Elgato"
-		});
-	});
-
-	/**
-	 * Asserts {@link StreamDeckClient.onApplicationDidLaunch} invokes the listener when the connection emits the `applicationDidLaunch` event.
-	 */
-	it("Receives onApplicationDidLaunch", () => {
-		// Arrange.
-		const { connection, client } = getMockedClient();
-
-		const listener = jest.fn();
-		client.onApplicationDidLaunch(listener);
-
-		// Act.
-		const {
-			payload: { application }
-		} = connection.__emit(mockEvents.applicationDidLaunch);
-
-		//Assert.
-		expect(listener).toHaveBeenCalledTimes(1);
-		expect(listener).toHaveBeenCalledWith<[ApplicationDidLaunchEvent]>({
-			application,
-			type: "applicationDidLaunch"
-		});
-	});
-
-	/**
-	 * Asserts {@link StreamDeckClient.onApplicationDidTerminate} invokes the listener when the connection emits the `applicationDidTerminate` event.
-	 */
-	it("Receives onApplicationDidTerminate", () => {
-		// Arrange.
-		const { connection, client } = getMockedClient();
-
-		const listener = jest.fn();
-		client.onApplicationDidTerminate(listener);
-
-		// Act.
-		const {
-			payload: { application }
-		} = connection.__emit(mockEvents.applicationDidTerminate);
-
-		//Assert.
-		expect(listener).toHaveBeenCalledTimes(1);
-		expect(listener).toHaveBeenCalledWith<[ApplicationDidTerminateEvent]>({
-			application,
-			type: "applicationDidTerminate"
 		});
 	});
 
@@ -470,26 +420,6 @@ describe("StreamDeckClient", () => {
 	});
 
 	/**
-	 * Asserts {@link StreamDeckClient.onSystemDidWakeUp} invokes the listener when the connection emits the `systemDidWakeUp` event.
-	 */
-	it("Receives onSystemDidWakeUp", () => {
-		// Arrange.
-		const { connection, client } = getMockedClient();
-
-		const listener = jest.fn();
-		client.onSystemDidWakeUp(listener);
-
-		// Act.
-		connection.__emit(mockEvents.systemDidWakeUp);
-
-		// Assert.
-		expect(listener).toHaveBeenCalledTimes(1);
-		expect(listener).toHaveBeenCalledWith<[SystemDidWakeUpEvent]>({
-			type: "systemDidWakeUp"
-		});
-	});
-
-	/**
 	 * Asserts {@link StreamDeckClient.onTitleParametersDidChange} invokes the listener when the connection emits the `titleParametersDidChange` event.
 	 */
 	it("Receives onTitleParametersDidChange", () => {
@@ -578,26 +508,6 @@ describe("StreamDeckClient", () => {
 			deviceId: device,
 			payload,
 			type: "willDisappear"
-		});
-	});
-
-	/**
-	 * Asserts {@link StreamDeckClient.openUrl} sends the command to the underlying {@link StreamDeckConnection}.
-	 */
-	it("Sends openUrl", async () => {
-		// Arrange.
-		const { connection, client } = getMockedClient();
-
-		// Act.
-		await client.openUrl("https://www.elgato.com");
-
-		// Assert.
-		expect(connection.send).toHaveBeenCalledTimes(1);
-		expect(connection.send).toHaveBeenCalledWith<[OpenUrl]>({
-			event: "openUrl",
-			payload: {
-				url: "https://www.elgato.com"
-			}
 		});
 	});
 

--- a/src/__tests__/stream-deck.test.ts
+++ b/src/__tests__/stream-deck.test.ts
@@ -9,6 +9,7 @@ import * as logging from "../logging";
 import { createLogger } from "../logging";
 import { getManifest } from "../manifest";
 import { StreamDeck } from "../stream-deck";
+import { System } from "../system";
 
 jest.mock("../actions/actions-controller");
 jest.mock("../client");
@@ -18,6 +19,7 @@ jest.mock("../devices");
 jest.mock("../i18n");
 jest.mock("../logging");
 jest.mock("../manifest");
+jest.mock("../system");
 
 describe("StreamDeck", () => {
 	beforeEach(async () => {
@@ -51,6 +53,7 @@ describe("StreamDeck", () => {
 		expect(StreamDeckClient).toHaveBeenCalledTimes(0);
 		expect(StreamDeckConnection).toHaveBeenCalledTimes(0);
 		expect(RegistrationParameters).toHaveBeenCalledTimes(0);
+		expect(System).toHaveBeenCalledTimes(0);
 	});
 
 	/**
@@ -68,6 +71,7 @@ describe("StreamDeck", () => {
 			expect(streamDeck.info).not.toBeUndefined();
 			expect(streamDeck.logger).not.toBeUndefined();
 			expect(streamDeck.manifest).not.toBeUndefined();
+			expect(streamDeck.system).not.toBeUndefined();
 		};
 
 		const expectInitializedOnce = () => {
@@ -79,6 +83,7 @@ describe("StreamDeck", () => {
 			expect(StreamDeckClient).toHaveBeenCalledTimes(1);
 			expect(StreamDeckConnection).toHaveBeenCalledTimes(1);
 			expect(RegistrationParameters).toHaveBeenCalledTimes(1);
+			expect(System).toHaveBeenCalledTimes(1);
 		};
 
 		// Act, assert.
@@ -198,6 +203,22 @@ describe("StreamDeck", () => {
 			expect(getManifest).toHaveBeenCalledTimes(1);
 			expect(getManifest).toHaveBeenCalledWith();
 		});
+
+		/**
+		 * Asserts accessing the {@link StreamDeck.system} correctly loads its dependencies and dependents.
+		 */
+		it("system", async () => {
+			// Arrange, act.
+			const streamDeck = new StreamDeck() as any;
+			const { system } = streamDeck;
+
+			// Assert.
+			expect(system).not.toBeUndefined();
+
+			const { _connection } = streamDeck;
+			expect(System).toHaveBeenCalledTimes(1);
+			expect(System).toHaveBeenCalledWith(_connection);
+		});
 	});
 
 	describe("Only initializes dependencies and dependents", () => {
@@ -220,6 +241,7 @@ describe("StreamDeck", () => {
 			expect(StreamDeckClient).toHaveBeenCalledTimes(1);
 			expect(StreamDeckConnection).toHaveBeenCalledTimes(1);
 			expect(RegistrationParameters).toHaveBeenCalledTimes(1);
+			expect(System).toHaveBeenCalledTimes(0);
 		});
 
 		/**
@@ -241,6 +263,7 @@ describe("StreamDeck", () => {
 			expect(StreamDeckClient).toHaveBeenCalledTimes(1);
 			expect(StreamDeckConnection).toHaveBeenCalledTimes(1);
 			expect(RegistrationParameters).toHaveBeenCalledTimes(1);
+			expect(System).toHaveBeenCalledTimes(0);
 		});
 
 		/**
@@ -262,6 +285,7 @@ describe("StreamDeck", () => {
 			expect(StreamDeckClient).toHaveBeenCalledTimes(0);
 			expect(StreamDeckConnection).toHaveBeenCalledTimes(1);
 			expect(RegistrationParameters).toHaveBeenCalledTimes(1);
+			expect(System).toHaveBeenCalledTimes(0);
 		});
 
 		/**
@@ -283,6 +307,7 @@ describe("StreamDeck", () => {
 			expect(StreamDeckClient).toHaveBeenCalledTimes(0);
 			expect(StreamDeckConnection).toHaveBeenCalledTimes(0);
 			expect(RegistrationParameters).toHaveBeenCalledTimes(1);
+			expect(System).toHaveBeenCalledTimes(0);
 		});
 
 		/**
@@ -303,6 +328,7 @@ describe("StreamDeck", () => {
 			expect(StreamDeckClient).toHaveBeenCalledTimes(0);
 			expect(StreamDeckConnection).toHaveBeenCalledTimes(0);
 			expect(RegistrationParameters).toHaveBeenCalledTimes(1);
+			expect(System).toHaveBeenCalledTimes(0);
 		});
 
 		/**
@@ -324,6 +350,7 @@ describe("StreamDeck", () => {
 			expect(StreamDeckClient).toHaveBeenCalledTimes(0);
 			expect(StreamDeckConnection).toHaveBeenCalledTimes(0);
 			expect(RegistrationParameters).toHaveBeenCalledTimes(0);
+			expect(System).toHaveBeenCalledTimes(0);
 		});
 
 		/**
@@ -344,6 +371,29 @@ describe("StreamDeck", () => {
 			expect(StreamDeckClient).toHaveBeenCalledTimes(0);
 			expect(StreamDeckConnection).toHaveBeenCalledTimes(0);
 			expect(RegistrationParameters).toHaveBeenCalledTimes(0);
+			expect(System).toHaveBeenCalledTimes(0);
+		});
+
+		/**
+		 * Asserts {@link StreamDeck.system} is constructed with the correct dependencies
+		 */
+		it("system", () => {
+			// Arrange, act.
+			const { system } = new StreamDeck();
+
+			// Assert.
+			expect(system).not.toBeUndefined();
+			expect(system).toBeInstanceOf(System);
+
+			expect(ActionsController).toHaveBeenCalledTimes(0);
+			expect(getDevices).toHaveBeenCalledTimes(1);
+			expect(I18nProvider).toHaveBeenCalledTimes(0);
+			expect(createLogger).toHaveBeenCalledTimes(1);
+			expect(getManifest).toHaveBeenCalledTimes(0);
+			expect(StreamDeckClient).toHaveBeenCalledTimes(0);
+			expect(StreamDeckConnection).toHaveBeenCalledTimes(1);
+			expect(RegistrationParameters).toHaveBeenCalledTimes(1);
+			expect(System).toHaveBeenCalledTimes(1);
 		});
 	});
 

--- a/src/__tests__/system.test.ts
+++ b/src/__tests__/system.test.ts
@@ -1,0 +1,98 @@
+import { getMockedConnection } from "../../tests/__mocks__/connection";
+import * as mockEvents from "../connectivity/__mocks__/events";
+import { OpenUrl } from "../connectivity/commands";
+import { StreamDeckConnection } from "../connectivity/connection";
+import { ApplicationDidLaunchEvent, ApplicationDidTerminateEvent, SystemDidWakeUpEvent } from "../events";
+import { System } from "../system";
+
+describe("StreamDeckClient", () => {
+	/**
+	 * Asserts {@link System.onApplicationDidLaunch} invokes the listener when the connection emits the `applicationDidLaunch` event.
+	 */
+	it("Receives onApplicationDidLaunch", () => {
+		// Arrange.
+		const { connection } = getMockedConnection();
+		const system = new System(connection);
+
+		const listener = jest.fn();
+		system.onApplicationDidLaunch(listener);
+
+		// Act.
+		const {
+			payload: { application }
+		} = connection.__emit(mockEvents.applicationDidLaunch);
+
+		//Assert.
+		expect(listener).toHaveBeenCalledTimes(1);
+		expect(listener).toHaveBeenCalledWith<[ApplicationDidLaunchEvent]>({
+			application,
+			type: "applicationDidLaunch"
+		});
+	});
+
+	/**
+	 * Asserts {@link System.onApplicationDidTerminate} invokes the listener when the connection emits the `applicationDidTerminate` event.
+	 */
+	it("Receives onApplicationDidTerminate", () => {
+		// Arrange.
+		const { connection } = getMockedConnection();
+		const system = new System(connection);
+
+		const listener = jest.fn();
+		system.onApplicationDidTerminate(listener);
+
+		// Act.
+		const {
+			payload: { application }
+		} = connection.__emit(mockEvents.applicationDidTerminate);
+
+		//Assert.
+		expect(listener).toHaveBeenCalledTimes(1);
+		expect(listener).toHaveBeenCalledWith<[ApplicationDidTerminateEvent]>({
+			application,
+			type: "applicationDidTerminate"
+		});
+	});
+
+	/**
+	 * Asserts {@link System.onSystemDidWakeUp} invokes the listener when the connection emits the `systemDidWakeUp` event.
+	 */
+	it("Receives onSystemDidWakeUp", () => {
+		// Arrange.
+		const { connection } = getMockedConnection();
+		const system = new System(connection);
+
+		const listener = jest.fn();
+		system.onSystemDidWakeUp(listener);
+
+		// Act.
+		connection.__emit(mockEvents.systemDidWakeUp);
+
+		// Assert.
+		expect(listener).toHaveBeenCalledTimes(1);
+		expect(listener).toHaveBeenCalledWith<[SystemDidWakeUpEvent]>({
+			type: "systemDidWakeUp"
+		});
+	});
+
+	/**
+	 * Asserts {@link System.openUrl} sends the command to the underlying {@link StreamDeckConnection}.
+	 */
+	it("Sends openUrl", async () => {
+		// Arrange.
+		const { connection } = getMockedConnection();
+		const system = new System(connection);
+
+		// Act.
+		await system.openUrl("https://www.elgato.com");
+
+		// Assert.
+		expect(connection.send).toHaveBeenCalledTimes(1);
+		expect(connection.send).toHaveBeenCalledWith<[OpenUrl]>({
+			event: "openUrl",
+			payload: {
+				url: "https://www.elgato.com"
+			}
+		});
+	});
+});

--- a/src/client.ts
+++ b/src/client.ts
@@ -7,9 +7,6 @@ import { Device } from "./devices";
 import {
 	ActionEvent,
 	ActionWithoutPayloadEvent,
-	ApplicationDidLaunchEvent,
-	ApplicationDidTerminateEvent,
-	ApplicationEvent,
 	DeviceDidConnectEvent,
 	DeviceDidDisconnectEvent,
 	DeviceEvent,
@@ -18,19 +15,16 @@ import {
 	DialUpEvent,
 	DidReceiveGlobalSettingsEvent,
 	DidReceiveSettingsEvent,
-	Event,
 	KeyDownEvent,
 	KeyUpEvent,
 	PropertyInspectorDidAppearEvent,
 	PropertyInspectorDidDisappearEvent,
 	SendToPluginEvent,
-	SystemDidWakeUpEvent,
 	TitleParametersDidChangeEvent,
 	TouchTapEvent,
 	WillAppearEvent,
 	WillDisappearEvent
 } from "./events";
-import type { Manifest } from "./manifest";
 
 /**
  * Provides the main bridge between the plugin and the Stream Deck allowing the plugin to send requests and receive events, e.g. when the user presses an action.
@@ -83,24 +77,6 @@ export class StreamDeckClient {
 				context
 			});
 		});
-	}
-
-	/**
-	 * Occurs when a monitored application is launched. Monitored applications can be defined in the manifest via the {@link Manifest.ApplicationsToMonitor} property.
-	 * Also see {@link StreamDeckClient.onApplicationDidTerminate}.
-	 * @param listener Function to be invoked when the event occurs.
-	 */
-	public onApplicationDidLaunch(listener: (ev: ApplicationDidLaunchEvent) => void): void {
-		this.connection.on("applicationDidLaunch", (ev) => listener(new ApplicationEvent(ev)));
-	}
-
-	/**
-	 * Occurs when a monitored application terminates. Monitored applications can be defined in the manifest via the {@link Manifest.ApplicationsToMonitor} property.
-	 * Also see {@link StreamDeckClient.onApplicationDidLaunch}.
-	 * @param listener Function to be invoked when the event occurs.
-	 */
-	public onApplicationDidTerminate(listener: (ev: ApplicationDidTerminateEvent) => void): void {
-		this.connection.on("applicationDidTerminate", (ev) => listener(new ApplicationEvent(ev)));
 	}
 
 	/**
@@ -228,14 +204,6 @@ export class StreamDeckClient {
 	}
 
 	/**
-	 * Occurs when the computer wakes up.
-	 * @param listener Function to be invoked when the event occurs.
-	 */
-	public onSystemDidWakeUp(listener: (ev: SystemDidWakeUpEvent) => void): void {
-		this.connection.on("systemDidWakeUp", (ev) => listener(new Event<api.SystemDidWakeUp>(ev)));
-	}
-
-	/**
 	 * Occurs when the user updates an action's title settings in the Stream Deck application. Also see {@link StreamDeckClient.setTitle}.
 	 * @template T The type of settings associated with the action.
 	 * @param listener Function to be invoked when the event occurs.
@@ -271,20 +239,6 @@ export class StreamDeckClient {
 	 */
 	public onWillDisappear<T extends api.PayloadObject<T> = object>(listener: (ev: WillDisappearEvent<T>) => void): void {
 		this.connection.on("willDisappear", (ev: api.WillDisappear<T>) => listener(new ActionEvent<api.WillDisappear<T>>(this, ev)));
-	}
-
-	/**
-	 * Opens the specified `url` in the user's default browser.
-	 * @param url URL to open.
-	 * @returns `Promise` resolved when the request to open the `url` has been sent to Stream Deck.
-	 */
-	public openUrl(url: string): Promise<void> {
-		return this.connection.send({
-			event: "openUrl",
-			payload: {
-				url
-			}
-		});
 	}
 
 	/**

--- a/src/stream-deck.ts
+++ b/src/stream-deck.ts
@@ -4,8 +4,9 @@ import { StreamDeckConnection } from "./connectivity/connection";
 import { RegistrationInfo, RegistrationParameters } from "./connectivity/registration";
 import { Device, getDevices } from "./devices";
 import { I18nProvider } from "./i18n";
-import { createLogger, Logger } from "./logging";
-import { getManifest, Manifest } from "./manifest";
+import { Logger, createLogger } from "./logging";
+import { Manifest, getManifest } from "./manifest";
+import { System } from "./system";
 
 /**
  * Defines the default export of this library.
@@ -50,6 +51,11 @@ export class StreamDeck {
 	 * Private backing field for {@link StreamDeck.registrationParameters}
 	 */
 	private _registrationParameters: RegistrationParameters | undefined;
+
+	/**
+	 * Private backing field for {@link StreamDeck.system};
+	 */
+	private _system: System | undefined;
 
 	/**
 	 * Provides information about, and methods for interacting with, actions associated with the Stream Deck plugin.
@@ -110,6 +116,14 @@ export class StreamDeck {
 	 */
 	public get manifest(): Omit<Manifest, "$schema"> {
 		return this._manifest || (this._manifest = getManifest());
+	}
+
+	/**
+	 * Provides events and methods for interacting with the system, e.g. monitoring applications or when the system wakes, etc.
+	 * @returns The {@link System}.
+	 */
+	public get system(): System {
+		return this._system || (this._system = new System(this.connection));
 	}
 
 	/**

--- a/src/system.ts
+++ b/src/system.ts
@@ -1,0 +1,55 @@
+import { StreamDeckConnection } from "./connectivity/connection";
+import type { SystemDidWakeUp } from "./connectivity/events";
+import { ApplicationDidLaunchEvent, ApplicationDidTerminateEvent, ApplicationEvent, Event, SystemDidWakeUpEvent } from "./events";
+import type { Manifest } from "./manifest";
+
+/**
+ * Provides events and methods for interacting with the system, e.g. monitoring applications or when the system wakes, etc.
+ */
+export class System {
+	/**
+	 * Initializes a new instance of the {@link System} class.
+	 * @param connection Underlying connection with the Stream Deck.
+	 */
+	constructor(private readonly connection: StreamDeckConnection) {}
+
+	/**
+	 * Occurs when a monitored application is launched. Monitored applications can be defined in the manifest via the {@link Manifest.ApplicationsToMonitor} property.
+	 * Also see {@link System.onApplicationDidTerminate}.
+	 * @param listener Function to be invoked when the event occurs.
+	 */
+	public onApplicationDidLaunch(listener: (ev: ApplicationDidLaunchEvent) => void): void {
+		this.connection.on("applicationDidLaunch", (ev) => listener(new ApplicationEvent(ev)));
+	}
+
+	/**
+	 * Occurs when a monitored application terminates. Monitored applications can be defined in the manifest via the {@link Manifest.ApplicationsToMonitor} property.
+	 * Also see {@link System.onApplicationDidLaunch}.
+	 * @param listener Function to be invoked when the event occurs.
+	 */
+	public onApplicationDidTerminate(listener: (ev: ApplicationDidTerminateEvent) => void): void {
+		this.connection.on("applicationDidTerminate", (ev) => listener(new ApplicationEvent(ev)));
+	}
+
+	/**
+	 * Occurs when the computer wakes up.
+	 * @param listener Function to be invoked when the event occurs.
+	 */
+	public onSystemDidWakeUp(listener: (ev: SystemDidWakeUpEvent) => void): void {
+		this.connection.on("systemDidWakeUp", (ev) => listener(new Event<SystemDidWakeUp>(ev)));
+	}
+
+	/**
+	 * Opens the specified `url` in the user's default browser.
+	 * @param url URL to open.
+	 * @returns `Promise` resolved when the request to open the `url` has been sent to Stream Deck.
+	 */
+	public openUrl(url: string): Promise<void> {
+		return this.connection.send({
+			event: "openUrl",
+			payload: {
+				url
+			}
+		});
+	}
+}

--- a/tests/__mocks__/connection.ts
+++ b/tests/__mocks__/connection.ts
@@ -1,0 +1,34 @@
+import type { MockStreamDeckConnection } from "../../src/connectivity/__mocks__/connection";
+import { StreamDeckConnection } from "../../src/connectivity/connection";
+import { RegistrationParameters } from "../../src/connectivity/registration";
+import type { Logger } from "../../src/logging";
+import { getMockedLogger } from "./logging";
+
+jest.mock("../../src/connectivity/connection");
+jest.mock("../../src/connectivity/registration");
+
+/**
+ * Gets a mocked {@link StreamDeckConnection}, and the accompanying {@link Logger}.
+ * @returns The mocked {@link StreamDeckConnection}.
+ */
+export function getMockedConnection() {
+	const { logger, scopedLogger } = getMockedLogger();
+	const connection = new StreamDeckConnection(new RegistrationParameters([], logger), logger) as MockStreamDeckConnection;
+
+	return {
+		/**
+		 * Mocked {@link StreamDeckConnection}.
+		 */
+		connection,
+
+		/**
+		 * Mocked {@link Logger}.
+		 */
+		logger,
+
+		/**
+		 * The mocked scoped {@link Logger} returned when calling {@link Logger.createScope}.
+		 */
+		scopedLogger
+	};
+}


### PR DESCRIPTION
- Add `streamDeck.system` namespace.
- Relocate `streamDeck.client.onApplicationDidLaunch` to `streamDeck.system.onApplicationDidLaunch`
- Relocate `streamDeck.client.onApplicationDidTerminate` to `streamDeck.system.onApplicationDidTerminate`
- Relocate `streamDeck.client.onSystemDidWakeUp` to `streamDeck.system.onSystemDidWakeUp`
- Relocate `streamDeck.client.openUrl` to `streamDeck.system.openUrl`