### PR TITLE
fix: re-structure controller type to not require exporting

### DIFF
--- a/src/connectivity/__mocks__/events.ts
+++ b/src/connectivity/__mocks__/events.ts
@@ -1,6 +1,5 @@
 import { DeviceType } from "../device-info";
 import type * as events from "../events";
-import { Controller } from "../events/action";
 
 const action = "com.elgato.test.one";
 const context = "context123";
@@ -59,7 +58,7 @@ export const dialDown: events.DialDown<Settings> = {
 	context,
 	device,
 	payload: {
-		controller: Controller.Encoder,
+		controller: "Encoder",
 		coordinates: {
 			column: 3,
 			row: 0
@@ -79,7 +78,7 @@ export const dialRotate: events.DialRotate<Settings> = {
 	context,
 	device,
 	payload: {
-		controller: Controller.Encoder,
+		controller: "Encoder",
 		coordinates: {
 			column: 3,
 			row: 0
@@ -121,7 +120,7 @@ export const didReceiveSettings: events.DidReceiveSettings<Settings> = {
 	device,
 	event: "didReceiveSettings",
 	payload: {
-		controller: Controller.Encoder,
+		controller: "Encoder",
 		coordinates: {
 			column: 1,
 			row: 0
@@ -142,7 +141,7 @@ export const keyDown: events.KeyDown<Settings> = {
 	device,
 	event: "keyDown",
 	payload: {
-		controller: Controller.Keypad,
+		controller: "Keypad",
 		coordinates: {
 			column: 2,
 			row: 2
@@ -209,7 +208,7 @@ export const titleParametersDidChange: events.TitleParametersDidChange<Settings>
 	device,
 	event: "titleParametersDidChange",
 	payload: {
-		controller: Controller.Keypad,
+		controller: "Keypad",
 		coordinates: {
 			column: 3,
 			row: 4
@@ -240,7 +239,7 @@ export const touchTap: events.TouchTap<Settings> = {
 	device,
 	event: "touchTap",
 	payload: {
-		controller: Controller.Encoder,
+		controller: "Encoder",
 		coordinates: {
 			column: 4,
 			row: 0
@@ -262,7 +261,7 @@ export const willAppear: events.WillAppear<Settings> = {
 	device,
 	event: "willAppear",
 	payload: {
-		controller: Controller.Keypad,
+		controller: "Keypad",
 		coordinates: {
 			column: 8,
 			row: 2

--- a/src/connectivity/events/__tests__/action.test.ts
+++ b/src/connectivity/events/__tests__/action.test.ts
@@ -1,17 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { Controller, Coordinates, State, WillAppear, WillDisappear } from "..";
+import { Coordinates, WillAppear, WillDisappear } from "..";
 import { Expect, TypesAreEqual } from "../../../../tests/utils";
 import { Settings } from "../../__mocks__/events";
-
-describe("Controller", () => {
-	/**
-	 * Asserts the values associated with {@link Controller} match Stream Deck values.
-	 */
-	it("should match Stream Deck payload values", () => {
-		expect(Controller.Encoder).toBe("Encoder");
-		expect(Controller.Keypad).toBe("Keypad");
-	});
-});
 
 describe("action event types", () => {
 	/**
@@ -28,10 +18,10 @@ describe("action event types", () => {
 						readonly device: string;
 						readonly payload: {
 							readonly isInMultiAction: false;
-							readonly controller: Controller;
+							readonly controller: "Encoder" | "Keypad";
 							readonly coordinates: Coordinates;
 							settings: Settings;
-							readonly state?: State;
+							readonly state?: 0 | 1;
 						};
 				  }
 				| {
@@ -41,9 +31,9 @@ describe("action event types", () => {
 						readonly device: string;
 						readonly payload: {
 							readonly isInMultiAction: true;
-							readonly controller: Controller.Keypad;
+							readonly controller: "Keypad";
 							settings: Settings;
-							readonly state?: State;
+							readonly state?: 0 | 1;
 						};
 				  }
 			>
@@ -64,10 +54,10 @@ describe("action event types", () => {
 						readonly device: string;
 						readonly payload: {
 							readonly isInMultiAction: false;
-							readonly controller: Controller;
+							readonly controller: "Encoder" | "Keypad";
 							readonly coordinates: Coordinates;
 							settings: Settings;
-							readonly state?: State;
+							readonly state?: 0 | 1;
 						};
 				  }
 				| {
@@ -77,9 +67,9 @@ describe("action event types", () => {
 						readonly device: string;
 						readonly payload: {
 							readonly isInMultiAction: true;
-							readonly controller: Controller.Keypad;
+							readonly controller: "Keypad";
 							settings: Settings;
-							readonly state?: State;
+							readonly state?: 0 | 1;
 						};
 				  }
 			>

--- a/src/connectivity/events/action.ts
+++ b/src/connectivity/events/action.ts
@@ -137,7 +137,7 @@ export type MultiActionPayload<TSettings extends PayloadObject<TSettings>> = Act
 	 *
 	 * **NB.** Requires Stream Deck 6.5 for `WillAppear` and `WillDisappear` events.
 	 */
-	readonly controller: Controller.Keypad;
+	readonly controller: "Keypad";
 
 	/**
 	 * Determines whether the action is part of a multi-action.
@@ -164,17 +164,7 @@ type ActionPayload<TSettings extends PayloadObject<TSettings>> = {
  * Defines the controller type the action is applicable to. **Keypad** refers to a standard action on a Stream Deck device, e.g. 1 of the 15 buttons on the Stream Deck MK.2, or a pedal
  * on the Stream Deck Pedal, etc., whereas an **Encoder** refers to a dial / touchscreen on the Stream Deck+.
  */
-export enum Controller {
-	/**
-	 * Encoder, represented as a dial and touch screen, as found on a Stream Deck+.
-	 */
-	Encoder = "Encoder",
-
-	/**
-	 * Key action, e.g. a button, pedal, or G-Key.
-	 */
-	Keypad = "Keypad"
-}
+export type Controller = "Encoder" | "Keypad";
 
 /**
  * Coordinates that identify the location of an action.

--- a/src/connectivity/events/encoder.ts
+++ b/src/connectivity/events/encoder.ts
@@ -1,4 +1,4 @@
-import type { ActionEventMessage, Controller, Coordinates, SingleActionPayload } from "./action";
+import type { ActionEventMessage, Coordinates, SingleActionPayload } from "./action";
 import type { PayloadObject } from "./index";
 
 /**
@@ -50,7 +50,7 @@ export type TouchTap<TSettings extends PayloadObject<TSettings>> = ActionEventMe
 /**
  * Additional information about the action and event that occurred.
  */
-type EncoderPayload<TSettings extends PayloadObject<TSettings>> = Pick<SingleActionPayload<TSettings, Extract<Controller, "Encoder">>, "controller" | "settings"> & {
+type EncoderPayload<TSettings extends PayloadObject<TSettings>> = Pick<SingleActionPayload<TSettings, "Encoder">, "controller" | "settings"> & {
 	/**
 	 * Coordinates that identify the location of the action.
 	 */

--- a/src/connectivity/events/index.ts
+++ b/src/connectivity/events/index.ts
@@ -5,10 +5,9 @@ import type { KeyDown, KeyUp } from "./keypad";
 import type { PropertyInspectorDidAppear, PropertyInspectorDidDisappear, SendToPlugin } from "./property-inspector";
 import type { ApplicationDidLaunch, ApplicationDidTerminate, DidReceiveDeepLink, DidReceiveGlobalSettings, SystemDidWakeUp } from "./system";
 
-export type { ActionIdentifier, State } from "./action";
+export type { ActionIdentifier, Controller, State } from "./action";
 export type { DeviceIdentifier } from "./device";
 
-export { Controller } from "./action";
 export type { Coordinates, DidReceiveSettings, TitleParametersDidChange, WillAppear, WillDisappear } from "./action";
 export type { DeviceDidConnect, DeviceDidDisconnect } from "./device";
 export type { DialDown, DialRotate, DialUp, TouchTap } from "./encoder";

--- a/src/connectivity/events/keypad.ts
+++ b/src/connectivity/events/keypad.ts
@@ -1,4 +1,4 @@
-import type { ActionEventMessage, Controller, MultiActionPayload, SingleActionPayload, State } from "./action";
+import type { ActionEventMessage, MultiActionPayload, SingleActionPayload, State } from "./action";
 import type { DialDown, DialUp } from "./encoder";
 import type { PayloadObject } from "./index";
 
@@ -16,7 +16,7 @@ export type KeyUp<TSettings extends PayloadObject<TSettings>> = ActionEventMessa
  * Additional information about a keypad event that occurred.
  */
 type KeypadPayload<TSettings extends PayloadObject<TSettings>> =
-	| SingleActionPayload<TSettings, Controller.Keypad>
+	| SingleActionPayload<TSettings, "Keypad">
 	| (MultiActionPayload<TSettings> & {
 			/**
 			 * Desired state as specified by the user; only applicable to actions that have multiple states defined within the `manifest.json` file, and when this action instance is


### PR DESCRIPTION
This change replaces the new `Controller` enum back to the previous union type to allow for implicit access, e.g.
```ts
onWillDisappear(ev: WillDisappearEvent): void {
  if (ev.payload.controller === "Keypad") {
    // do something.
  }
}
```