### PR TITLE
docs: improve JSON schema documentation and validation

### DIFF
--- a/schemas/layout.json
+++ b/schemas/layout.json
@@ -77,11 +77,11 @@
 									},
 									"bar_bg_c": {
 										"type": "string",
-										"description": "Bar background color represented as a named color, hexadecimal value, or gradient. Default is `darkGray`. **NB** Gradients can be defined by specifying multiple color-stops separated by commas, in the following format `[{offset}:{color}[,]]`.\n\n**Examples:**\n- \"pink\"\n- \"#204cfe\" (Elgato blue)\n- \"0:#ff0000,0.5:yellow,1:#00ff00\" (Gradient)",
+										"description": "Bar background color represented as a named color, hexadecimal value, or gradient. Default is `darkGray`. Gradients can be defined by specifying multiple color-stops separated by commas, in the following format `[{offset}:{color}[,]]`.\n\n**Examples:**\n- \"pink\"\n- \"#204cfe\" (Elgato blue)\n- \"0:#ff0000,0.5:yellow,1:#00ff00\" (Gradient)",
 										"examples": [
 											"darkGray"
 										],
-										"markdownDescription": "Bar background color represented as a named color, hexadecimal value, or gradient. Default is `darkGray`. **NB** Gradients can be defined by specifying multiple color-stops separated by commas, in the following format `[{offset}:{color}[,]]`.\n\n**Examples:**\n- \"pink\"\n- \"#204cfe\" (Elgato blue)\n- \"0:#ff0000,0.5:yellow,1:#00ff00\" (Gradient)"
+										"markdownDescription": "Bar background color represented as a named color, hexadecimal value, or gradient. Default is `darkGray`. Gradients can be defined by specifying multiple color-stops separated by commas, in the following format `[{offset}:{color}[,]]`.\n\n**Examples:**\n- \"pink\"\n- \"#204cfe\" (Elgato blue)\n- \"0:#ff0000,0.5:yellow,1:#00ff00\" (Gradient)"
 									},
 									"bar_border_c": {
 										"type": "string",
@@ -93,11 +93,11 @@
 									},
 									"bar_fill_c": {
 										"type": "string",
-										"description": "Fill color of the bar represented as a named color, hexadecimal value, or gradient. Default is `white`. **NB** Gradients can be defined by specifying multiple color-stops separated by commas, in the following format `[{offset}:{color}[,]]`.\n\n**Examples:**\n- \"pink\"\n- \"#204cfe\" (Elgato blue)\n- \"0:#ff0000,0.5:yellow,1:#00ff00\" (Gradient)",
+										"description": "Fill color of the bar represented as a named color, hexadecimal value, or gradient. Default is `white`. Gradients can be defined by specifying multiple color-stops separated by commas, in the following format `[{offset}:{color}[,]]`.\n\n**Examples:**\n- \"pink\"\n- \"#204cfe\" (Elgato blue)\n- \"0:#ff0000,0.5:yellow,1:#00ff00\" (Gradient)",
 										"examples": [
 											"white"
 										],
-										"markdownDescription": "Fill color of the bar represented as a named color, hexadecimal value, or gradient. Default is `white`. **NB** Gradients can be defined by specifying multiple color-stops separated by commas, in the following format `[{offset}:{color}[,]]`.\n\n**Examples:**\n- \"pink\"\n- \"#204cfe\" (Elgato blue)\n- \"0:#ff0000,0.5:yellow,1:#00ff00\" (Gradient)"
+										"markdownDescription": "Fill color of the bar represented as a named color, hexadecimal value, or gradient. Default is `white`. Gradients can be defined by specifying multiple color-stops separated by commas, in the following format `[{offset}:{color}[,]]`.\n\n**Examples:**\n- \"pink\"\n- \"#204cfe\" (Elgato blue)\n- \"0:#ff0000,0.5:yellow,1:#00ff00\" (Gradient)"
 									},
 									"border_w": {
 										"type": "number",
@@ -141,8 +141,8 @@
 									},
 									"background": {
 										"type": "string",
-										"description": "Background color represented as a named color, hexadecimal value, or gradient. **NB** Gradients can be defined by specifying multiple color-stops separated by commas, in the following format `[{offset}:{color}[,]]`.\n\n**Examples:**\n- \"pink\"\n- \"#204cfe\" (Elgato blue)\n- \"0:#ff0000,0.5:yellow,1:#00ff00\" (Gradient)",
-										"markdownDescription": "Background color represented as a named color, hexadecimal value, or gradient. **NB** Gradients can be defined by specifying multiple color-stops separated by commas, in the following format `[{offset}:{color}[,]]`.\n\n**Examples:**\n- \"pink\"\n- \"#204cfe\" (Elgato blue)\n- \"0:#ff0000,0.5:yellow,1:#00ff00\" (Gradient)"
+										"description": "Background color represented as a named color, hexadecimal value, or gradient. Gradients can be defined by specifying multiple color-stops separated by commas, in the following format `[{offset}:{color}[,]]`.\n\n**Examples:**\n- \"pink\"\n- \"#204cfe\" (Elgato blue)\n- \"0:#ff0000,0.5:yellow,1:#00ff00\" (Gradient)",
+										"markdownDescription": "Background color represented as a named color, hexadecimal value, or gradient. Gradients can be defined by specifying multiple color-stops separated by commas, in the following format `[{offset}:{color}[,]]`.\n\n**Examples:**\n- \"pink\"\n- \"#204cfe\" (Elgato blue)\n- \"0:#ff0000,0.5:yellow,1:#00ff00\" (Gradient)"
 									},
 									"enabled": {
 										"type": "boolean",
@@ -250,11 +250,11 @@
 									},
 									"bar_bg_c": {
 										"type": "string",
-										"description": "Bar background color represented as a named color, hexadecimal value, or gradient. Default is `darkGray`. **NB** Gradients can be defined by specifying multiple color-stops separated by commas, in the following format `[{offset}:{color}[,]]`.\n\n**Examples:**\n- \"pink\"\n- \"#204cfe\" (Elgato blue)\n- \"0:#ff0000,0.5:yellow,1:#00ff00\" (Gradient)",
+										"description": "Bar background color represented as a named color, hexadecimal value, or gradient. Default is `darkGray`. Gradients can be defined by specifying multiple color-stops separated by commas, in the following format `[{offset}:{color}[,]]`.\n\n**Examples:**\n- \"pink\"\n- \"#204cfe\" (Elgato blue)\n- \"0:#ff0000,0.5:yellow,1:#00ff00\" (Gradient)",
 										"examples": [
 											"darkGray"
 										],
-										"markdownDescription": "Bar background color represented as a named color, hexadecimal value, or gradient. Default is `darkGray`. **NB** Gradients can be defined by specifying multiple color-stops separated by commas, in the following format `[{offset}:{color}[,]]`.\n\n**Examples:**\n- \"pink\"\n- \"#204cfe\" (Elgato blue)\n- \"0:#ff0000,0.5:yellow,1:#00ff00\" (Gradient)"
+										"markdownDescription": "Bar background color represented as a named color, hexadecimal value, or gradient. Default is `darkGray`. Gradients can be defined by specifying multiple color-stops separated by commas, in the following format `[{offset}:{color}[,]]`.\n\n**Examples:**\n- \"pink\"\n- \"#204cfe\" (Elgato blue)\n- \"0:#ff0000,0.5:yellow,1:#00ff00\" (Gradient)"
 									},
 									"bar_border_c": {
 										"type": "string",
@@ -266,11 +266,11 @@
 									},
 									"bar_fill_c": {
 										"type": "string",
-										"description": "Fill color of the bar represented as a named color, hexadecimal value, or gradient. Default is `white`. **NB** Gradients can be defined by specifying multiple color-stops separated by commas, in the following format `[{offset}:{color}[,]]`.\n\n**Examples:**\n- \"pink\"\n- \"#204cfe\" (Elgato blue)\n- \"0:#ff0000,0.5:yellow,1:#00ff00\" (Gradient)",
+										"description": "Fill color of the bar represented as a named color, hexadecimal value, or gradient. Default is `white`. Gradients can be defined by specifying multiple color-stops separated by commas, in the following format `[{offset}:{color}[,]]`.\n\n**Examples:**\n- \"pink\"\n- \"#204cfe\" (Elgato blue)\n- \"0:#ff0000,0.5:yellow,1:#00ff00\" (Gradient)",
 										"examples": [
 											"white"
 										],
-										"markdownDescription": "Fill color of the bar represented as a named color, hexadecimal value, or gradient. Default is `white`. **NB** Gradients can be defined by specifying multiple color-stops separated by commas, in the following format `[{offset}:{color}[,]]`.\n\n**Examples:**\n- \"pink\"\n- \"#204cfe\" (Elgato blue)\n- \"0:#ff0000,0.5:yellow,1:#00ff00\" (Gradient)"
+										"markdownDescription": "Fill color of the bar represented as a named color, hexadecimal value, or gradient. Default is `white`. Gradients can be defined by specifying multiple color-stops separated by commas, in the following format `[{offset}:{color}[,]]`.\n\n**Examples:**\n- \"pink\"\n- \"#204cfe\" (Elgato blue)\n- \"0:#ff0000,0.5:yellow,1:#00ff00\" (Gradient)"
 									},
 									"border_w": {
 										"type": "number",
@@ -314,8 +314,8 @@
 									},
 									"background": {
 										"type": "string",
-										"description": "Background color represented as a named color, hexadecimal value, or gradient. **NB** Gradients can be defined by specifying multiple color-stops separated by commas, in the following format `[{offset}:{color}[,]]`.\n\n**Examples:**\n- \"pink\"\n- \"#204cfe\" (Elgato blue)\n- \"0:#ff0000,0.5:yellow,1:#00ff00\" (Gradient)",
-										"markdownDescription": "Background color represented as a named color, hexadecimal value, or gradient. **NB** Gradients can be defined by specifying multiple color-stops separated by commas, in the following format `[{offset}:{color}[,]]`.\n\n**Examples:**\n- \"pink\"\n- \"#204cfe\" (Elgato blue)\n- \"0:#ff0000,0.5:yellow,1:#00ff00\" (Gradient)"
+										"description": "Background color represented as a named color, hexadecimal value, or gradient. Gradients can be defined by specifying multiple color-stops separated by commas, in the following format `[{offset}:{color}[,]]`.\n\n**Examples:**\n- \"pink\"\n- \"#204cfe\" (Elgato blue)\n- \"0:#ff0000,0.5:yellow,1:#00ff00\" (Gradient)",
+										"markdownDescription": "Background color represented as a named color, hexadecimal value, or gradient. Gradients can be defined by specifying multiple color-stops separated by commas, in the following format `[{offset}:{color}[,]]`.\n\n**Examples:**\n- \"pink\"\n- \"#204cfe\" (Elgato blue)\n- \"0:#ff0000,0.5:yellow,1:#00ff00\" (Gradient)"
 									},
 									"enabled": {
 										"type": "boolean",
@@ -420,8 +420,8 @@
 									},
 									"background": {
 										"type": "string",
-										"description": "Background color represented as a named color, hexadecimal value, or gradient. **NB** Gradients can be defined by specifying multiple color-stops separated by commas, in the following format `[{offset}:{color}[,]]`.\n\n**Examples:**\n- \"pink\"\n- \"#204cfe\" (Elgato blue)\n- \"0:#ff0000,0.5:yellow,1:#00ff00\" (Gradient)",
-										"markdownDescription": "Background color represented as a named color, hexadecimal value, or gradient. **NB** Gradients can be defined by specifying multiple color-stops separated by commas, in the following format `[{offset}:{color}[,]]`.\n\n**Examples:**\n- \"pink\"\n- \"#204cfe\" (Elgato blue)\n- \"0:#ff0000,0.5:yellow,1:#00ff00\" (Gradient)"
+										"description": "Background color represented as a named color, hexadecimal value, or gradient. Gradients can be defined by specifying multiple color-stops separated by commas, in the following format `[{offset}:{color}[,]]`.\n\n**Examples:**\n- \"pink\"\n- \"#204cfe\" (Elgato blue)\n- \"0:#ff0000,0.5:yellow,1:#00ff00\" (Gradient)",
+										"markdownDescription": "Background color represented as a named color, hexadecimal value, or gradient. Gradients can be defined by specifying multiple color-stops separated by commas, in the following format `[{offset}:{color}[,]]`.\n\n**Examples:**\n- \"pink\"\n- \"#204cfe\" (Elgato blue)\n- \"0:#ff0000,0.5:yellow,1:#00ff00\" (Gradient)"
 									},
 									"enabled": {
 										"type": "boolean",
@@ -571,8 +571,8 @@
 									},
 									"background": {
 										"type": "string",
-										"description": "Background color represented as a named color, hexadecimal value, or gradient. **NB** Gradients can be defined by specifying multiple color-stops separated by commas, in the following format `[{offset}:{color}[,]]`.\n\n**Examples:**\n- \"pink\"\n- \"#204cfe\" (Elgato blue)\n- \"0:#ff0000,0.5:yellow,1:#00ff00\" (Gradient)",
-										"markdownDescription": "Background color represented as a named color, hexadecimal value, or gradient. **NB** Gradients can be defined by specifying multiple color-stops separated by commas, in the following format `[{offset}:{color}[,]]`.\n\n**Examples:**\n- \"pink\"\n- \"#204cfe\" (Elgato blue)\n- \"0:#ff0000,0.5:yellow,1:#00ff00\" (Gradient)"
+										"description": "Background color represented as a named color, hexadecimal value, or gradient. Gradients can be defined by specifying multiple color-stops separated by commas, in the following format `[{offset}:{color}[,]]`.\n\n**Examples:**\n- \"pink\"\n- \"#204cfe\" (Elgato blue)\n- \"0:#ff0000,0.5:yellow,1:#00ff00\" (Gradient)",
+										"markdownDescription": "Background color represented as a named color, hexadecimal value, or gradient. Gradients can be defined by specifying multiple color-stops separated by commas, in the following format `[{offset}:{color}[,]]`.\n\n**Examples:**\n- \"pink\"\n- \"#204cfe\" (Elgato blue)\n- \"0:#ff0000,0.5:yellow,1:#00ff00\" (Gradient)"
 									},
 									"enabled": {
 										"type": "boolean",

--- a/schemas/layout.json
+++ b/schemas/layout.json
@@ -561,7 +561,7 @@
 											"fade"
 										],
 										"description": "Defines how overflowing text should be rendered on the layout.\n- clip, truncates the text at the boundary of the element (default).\n- ellipsis, truncates the text prior to the boundary of the element, and adds an ellipsis (…) to the end.\n- fade, applies a fade-gradient over the end of the text.",
-										"default": "clip",
+										"default": "ellipsis",
 										"markdownDescription": "Defines how overflowing text should be rendered on the layout.\n- clip, truncates the text at the boundary of the element (default).\n- ellipsis, truncates the text prior to the boundary of the element, and adds an ellipsis (…) to the end.\n- fade, applies a fade-gradient over the end of the text."
 									},
 									"value": {

--- a/schemas/layout.json
+++ b/schemas/layout.json
@@ -130,9 +130,16 @@
 										"markdownDescription": "Defines the range of the value the bar represents, e.g. 0-20, 0-100, etc."
 									},
 									"subtype": {
-										"$ref": "#/definitions/BarSubType",
-										"description": "Sub-type used to determine the type of bar to render. Default is  {@link  BarSubType.Groove } .",
-										"markdownDescription": "Sub-type used to determine the type of bar to render. Default is  {@link  BarSubType.Groove } ."
+										"type": "number",
+										"enum": [
+											0,
+											1,
+											2,
+											3,
+											4
+										],
+										"description": "Sub-type used to determine the type of bar to render. Default is  {@link  BarSubType.Groove }  (4).\n\n**Options**\n- Rectangle (0)\n- DoubleRectangle (1)\n- Trapezoid (2)\n- DoubleTrapezoid (3)\n- Groove (4)",
+										"markdownDescription": "Sub-type used to determine the type of bar to render. Default is  {@link  BarSubType.Groove }  (4).\n\n**Options**\n- Rectangle (0)\n- DoubleRectangle (1)\n- Trapezoid (2)\n- DoubleTrapezoid (3)\n- Groove (4)"
 									},
 									"value": {
 										"type": "number",
@@ -303,9 +310,16 @@
 										"markdownDescription": "Defines the range of the value the bar represents, e.g. 0-20, 0-100, etc."
 									},
 									"subtype": {
-										"$ref": "#/definitions/BarSubType",
-										"description": "Sub-type used to determine the type of bar to render. Default is  {@link  BarSubType.Groove } .",
-										"markdownDescription": "Sub-type used to determine the type of bar to render. Default is  {@link  BarSubType.Groove } ."
+										"type": "number",
+										"enum": [
+											0,
+											1,
+											2,
+											3,
+											4
+										],
+										"description": "Sub-type used to determine the type of bar to render. Default is  {@link  BarSubType.Groove }  (4).\n\n**Options**\n- Rectangle (0)\n- DoubleRectangle (1)\n- Trapezoid (2)\n- DoubleTrapezoid (3)\n- Groove (4)",
+										"markdownDescription": "Sub-type used to determine the type of bar to render. Default is  {@link  BarSubType.Groove }  (4).\n\n**Options**\n- Rectangle (0)\n- DoubleRectangle (1)\n- Trapezoid (2)\n- DoubleTrapezoid (3)\n- Groove (4)"
 									},
 									"value": {
 										"type": "number",
@@ -626,18 +640,6 @@
 			"additionalProperties": false,
 			"description": "Defines the structure of a custom layout file.",
 			"markdownDescription": "Defines the structure of a custom layout file."
-		},
-		"BarSubType": {
-			"type": "number",
-			"enum": [
-				0,
-				1,
-				2,
-				3,
-				4
-			],
-			"description": "List of available types that can be applied to  {@link  Bar }  and  {@link  GBar }  to determine their style.",
-			"markdownDescription": "List of available types that can be applied to  {@link  Bar }  and  {@link  GBar }  to determine their style."
 		}
 	}
 }

--- a/schemas/manifest.json
+++ b/schemas/manifest.json
@@ -47,7 +47,7 @@
 									"Icon": {
 										"type": "string",
 										"description": "Path to the image, with the **file extension omitted**, that will be displayed in the Stream Deck application in the circular canvas that represents the dial of the action. The image must fulfill the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 72x72 px and 144x144 px (@2x).\n\n**NB.** This can be overridden by the user in the Stream Deck application.\n\n**Examples:**\n- assets/actions/mute/encoder-icon\n- imgs/join-voice-chat-encoder",
-										"pattern": "^(?!\\/).+(?<!\\.([Pp][Nn][Gg]|[Ss][Vv][Gg]))$",
+										"pattern": "^[^.]+$",
 										"markdownDescription": "Path to the image, with the **file extension omitted**, that will be displayed in the Stream Deck application in the circular canvas that represents the dial of the action. The image must fulfill the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 72x72 px and 144x144 px (@2x).\n\n**NB.** This can be overridden by the user in the Stream Deck application.\n\n**Examples:**\n- assets/actions/mute/encoder-icon\n- imgs/join-voice-chat-encoder"
 									},
 									"StackColor": {
@@ -87,7 +87,7 @@
 									"background": {
 										"type": "string",
 										"description": "Path to the image, with the **file extension omitted**, that will be displayed on the touchscreen behind the action's layout. The image must fulfill the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 200x100 px and 400x200 px (@2x).\n\n**NB.** This can be overridden by the user in the Stream Deck application\n\n**Examples:**\n- assets/backgrounds/main\n- imgs/bright-blue-bg",
-										"pattern": "^(?!\\/).+(?<!\\.([Pp][Nn][Gg]|[Ss][Vv][Gg]))$",
+										"pattern": "^[^.]+$",
 										"markdownDescription": "Path to the image, with the **file extension omitted**, that will be displayed on the touchscreen behind the action's layout. The image must fulfill the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 200x100 px and 400x200 px (@2x).\n\n**NB.** This can be overridden by the user in the Stream Deck application\n\n**Examples:**\n- assets/backgrounds/main\n- imgs/bright-blue-bg"
 									},
 									"layout": {
@@ -112,7 +112,7 @@
 							"Icon": {
 								"type": "string",
 								"description": "Path to the image, with the **file extension omitted**, that will be displayed next to the action in the Stream Deck application's action list. The image must adhere to the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 20x20 px and 40x40 px (@2x).\n- Be monochromatic, with foreground color of #EFEFEF and a transparent background.\n\n**Examples:**\n- assets/counter\n- imgs/actions/mute",
-								"pattern": "^(?!\\/).+(?<!\\.([Pp][Nn][Gg]|[Ss][Vv][Gg]))$",
+								"pattern": "^[^.]+$",
 								"markdownDescription": "Path to the image, with the **file extension omitted**, that will be displayed next to the action in the Stream Deck application's action list. The image must adhere to the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 20x20 px and 40x40 px (@2x).\n- Be monochromatic, with foreground color of #EFEFEF and a transparent background.\n\n**Examples:**\n- assets/counter\n- imgs/actions/mute"
 							},
 							"Name": {
@@ -161,13 +161,13 @@
 										"Image": {
 											"type": "string",
 											"description": "Path to the image, with the **file extension omitted**, that will be displayed on the Stream Deck when this action's state is active. The image must adhere to the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 72x72 px and 144x144 px (@2x).\n\n**NB.** This can be overridden by the user in the Stream Deck application.\n\n**Examples:**\n- assets/counter-key\n- assets/icons/mute",
-											"pattern": "^(?!\\/).+(?<!\\.([Pp][Nn][Gg]|[Ss][Vv][Gg]))$",
+											"pattern": "^[^.]+$",
 											"markdownDescription": "Path to the image, with the **file extension omitted**, that will be displayed on the Stream Deck when this action's state is active. The image must adhere to the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 72x72 px and 144x144 px (@2x).\n\n**NB.** This can be overridden by the user in the Stream Deck application.\n\n**Examples:**\n- assets/counter-key\n- assets/icons/mute"
 										},
 										"MultiActionImage": {
 											"type": "string",
 											"description": "Path to the image, with the **file extension omitted**, that will be displayed when the action is being viewed as part of a multi-action. The image must adhere to the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 72x72 px and 144x144 px (@2x).\n\n**NB.** This can be overridden by the user in the Stream Deck application.\n\n**Examples:**\n- assets/counter-key\n- assets/icons/mute",
-											"pattern": "^(?!\\/).+(?<!\\.([Pp][Nn][Gg]|[Ss][Vv][Gg]))$",
+											"pattern": "^[^.]+$",
 											"markdownDescription": "Path to the image, with the **file extension omitted**, that will be displayed when the action is being viewed as part of a multi-action. The image must adhere to the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 72x72 px and 144x144 px (@2x).\n\n**NB.** This can be overridden by the user in the Stream Deck application.\n\n**Examples:**\n- assets/counter-key\n- assets/icons/mute"
 										},
 										"Name": {
@@ -289,7 +289,7 @@
 				"CategoryIcon": {
 					"type": "string",
 					"description": "Path to the image, with the **file extension omitted**, that will be displayed next to the action list group within the Stream Deck application. The icon should accurately represent the plugin, and enable users to quickly identify the plugin. The icon must adhere to the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 28x28 px and 56x56 px (@2x).\n- Be monochromatic, with foreground color of #DFDFDF and a transparent background.\n\n**Examples**:\n- assets/category-icon\n- imgs/category",
-					"pattern": "^(?!\\/).+(?<!\\.([Pp][Nn][Gg]|[Ss][Vv][Gg]))$",
+					"pattern": "^[^.]+$",
 					"markdownDescription": "Path to the image, with the **file extension omitted**, that will be displayed next to the action list group within the Stream Deck application. The icon should accurately represent the plugin, and enable users to quickly identify the plugin. The icon must adhere to the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 28x28 px and 56x56 px (@2x).\n- Be monochromatic, with foreground color of #DFDFDF and a transparent background.\n\n**Examples**:\n- assets/category-icon\n- imgs/category"
 				},
 				"CodePath": {
@@ -331,7 +331,7 @@
 				"Icon": {
 					"type": "string",
 					"description": "Path to the image, with the **file extension omitted**, that will be displayed on the Marketplace. The icon should accurately represent the plugin, stand out, and enable users to quickly identify the plugin. The icon must adhere to the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 288x288 px and 512x512 px (@2x).\n\n**Examples**: assets/plugin-icon imgs/plugin",
-					"pattern": "^(?!\\/).+(?<!\\.([Pp][Nn][Gg]|[Ss][Vv][Gg]))$",
+					"pattern": "^[^.]+$",
 					"markdownDescription": "Path to the image, with the **file extension omitted**, that will be displayed on the Marketplace. The icon should accurately represent the plugin, stand out, and enable users to quickly identify the plugin. The icon must adhere to the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 288x288 px and 512x512 px (@2x).\n\n**Examples**: assets/plugin-icon imgs/plugin"
 				},
 				"Name": {

--- a/schemas/manifest.json
+++ b/schemas/manifest.json
@@ -409,9 +409,19 @@
 						"type": "object",
 						"properties": {
 							"DeviceType": {
-								"$ref": "#/definitions/DeviceType",
-								"description": "Type of device the profile is applicable too, e.g. Stream Deck+, Stream Deck Pedal, etc.",
-								"markdownDescription": "Type of device the profile is applicable too, e.g. Stream Deck+, Stream Deck Pedal, etc."
+								"type": "number",
+								"enum": [
+									0,
+									1,
+									2,
+									3,
+									4,
+									5,
+									6,
+									7
+								],
+								"description": "Type of device the profile is intended for, for example Stream Deck+, Stream Deck Pedal, etc.\n\n**Devices**\n- Stream Deck (0)\n- Stream Deck Mini (1)\n- Stream Deck XL (2)\n- Stream Deck Mobile (3)\n- Corsair GKeys (4)\n- Stream Deck Pedal (5)\n- Corsair Voyager (6)\n- Stream Deck Plus (7)",
+								"markdownDescription": "Type of device the profile is intended for, for example Stream Deck+, Stream Deck Pedal, etc.\n\n**Devices**\n- Stream Deck (0)\n- Stream Deck Mini (1)\n- Stream Deck XL (2)\n- Stream Deck Mobile (3)\n- Corsair GKeys (4)\n- Stream Deck Pedal (5)\n- Corsair Voyager (6)\n- Stream Deck Plus (7)"
 							},
 							"DontAutoSwitchWhenInstalled": {
 								"type": "boolean",
@@ -508,21 +518,6 @@
 			],
 			"description": "Defines the controller type the action is applicable to. **Keypad** refers to a standard action on a Stream Deck device, e.g. 1 of the 15 buttons on the Stream Deck MK.2, or a pedal on the Stream Deck Pedal, etc., whereas an **Encoder** refers to a dial / touchscreen on the Stream Deck+.",
 			"markdownDescription": "Defines the controller type the action is applicable to. **Keypad** refers to a standard action on a Stream Deck device, e.g. 1 of the 15 buttons on the Stream Deck MK.2, or a pedal on the Stream Deck Pedal, etc., whereas an **Encoder** refers to a dial / touchscreen on the Stream Deck+."
-		},
-		"DeviceType": {
-			"type": "number",
-			"enum": [
-				0,
-				1,
-				2,
-				3,
-				4,
-				5,
-				6,
-				7
-			],
-			"description": "Stream Deck device types.",
-			"markdownDescription": "Stream Deck device types."
 		}
 	}
 }

--- a/schemas/manifest.json
+++ b/schemas/manifest.json
@@ -46,9 +46,9 @@
 								"properties": {
 									"Icon": {
 										"type": "string",
-										"description": "Path to the image, with the **file extension omitted**, that will be displayed in the Stream Deck application in the circular canvas that represents the dial of the action. The image must fulfill the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 72x72 px and 144x144 px (@2x).\n\n**NB.** This can be overridden by the user in the Stream Deck application.\n\n**Examples:**\n- assets/actions/mute/encoder-icon\n- imgs/join-voice-chat-encoder",
+										"description": "Path to the image, with the **file extension omitted**, that will be displayed in the Stream Deck application in the circular canvas that represents the dial of the action. The image must fulfill the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 72x72 px and 144x144 px (@2x).\n\nNB: Can be overridden by the user in the Stream Deck application.\n\n**Examples:**\n- assets/actions/mute/encoder-icon\n- imgs/join-voice-chat-encoder",
 										"pattern": "^[^.]+$",
-										"markdownDescription": "Path to the image, with the **file extension omitted**, that will be displayed in the Stream Deck application in the circular canvas that represents the dial of the action. The image must fulfill the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 72x72 px and 144x144 px (@2x).\n\n**NB.** This can be overridden by the user in the Stream Deck application.\n\n**Examples:**\n- assets/actions/mute/encoder-icon\n- imgs/join-voice-chat-encoder"
+										"markdownDescription": "Path to the image, with the **file extension omitted**, that will be displayed in the Stream Deck application in the circular canvas that represents the dial of the action. The image must fulfill the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 72x72 px and 144x144 px (@2x).\n\nNB: Can be overridden by the user in the Stream Deck application.\n\n**Examples:**\n- assets/actions/mute/encoder-icon\n- imgs/join-voice-chat-encoder"
 									},
 									"StackColor": {
 										"type": "string",
@@ -86,9 +86,9 @@
 									},
 									"background": {
 										"type": "string",
-										"description": "Path to the image, with the **file extension omitted**, that will be displayed on the touchscreen behind the action's layout. The image must fulfill the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 200x100 px and 400x200 px (@2x).\n\n**NB.** This can be overridden by the user in the Stream Deck application\n\n**Examples:**\n- assets/backgrounds/main\n- imgs/bright-blue-bg",
+										"description": "Path to the image, with the **file extension omitted**, that will be displayed on the touchscreen behind the action's layout. The image must fulfill the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 200x100 px and 400x200 px (@2x).\n\nNB: Can be overridden by the user in the Stream Deck application.\n\n**Examples:**\n- assets/backgrounds/main\n- imgs/bright-blue-bg",
 										"pattern": "^[^.]+$",
-										"markdownDescription": "Path to the image, with the **file extension omitted**, that will be displayed on the touchscreen behind the action's layout. The image must fulfill the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 200x100 px and 400x200 px (@2x).\n\n**NB.** This can be overridden by the user in the Stream Deck application\n\n**Examples:**\n- assets/backgrounds/main\n- imgs/bright-blue-bg"
+										"markdownDescription": "Path to the image, with the **file extension omitted**, that will be displayed on the touchscreen behind the action's layout. The image must fulfill the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 200x100 px and 400x200 px (@2x).\n\nNB: Can be overridden by the user in the Stream Deck application.\n\n**Examples:**\n- assets/backgrounds/main\n- imgs/bright-blue-bg"
 									},
 									"layout": {
 										"type": "string",
@@ -122,9 +122,9 @@
 							},
 							"PropertyInspectorPath": {
 								"type": "string",
-								"description": "Optional path to the HTML file that represents the property inspector for this action; this is displayed to the user in the Stream Deck application when they add the action, allowing them to configure the action's settings. When `undefined`, the manifest's top-level `PropertyInspectorPath` is used, otherwise none. **NB.** Path should be relative to the root of the plugin's folder, with no leading slash.\n\n**Examples:**\n- mute.html\n- actions/join-voice-chat/settings.html",
+								"description": "Optional path to the HTML file that represents the property inspector for this action; this is displayed to the user in the Stream Deck application when they add the action, allowing them to configure the action's settings. When `undefined`, the manifest's top-level `PropertyInspectorPath` is used, otherwise none.\n\nNB: Path should be relative to the root of the plugin's folder, with no leading slash.\n\n**Examples:**\n- mute.html\n- actions/join-voice-chat/settings.html",
 								"pattern": "^(?!\\/).+\\.[Hh][Tt][Mm][Ll]?$",
-								"markdownDescription": "Optional path to the HTML file that represents the property inspector for this action; this is displayed to the user in the Stream Deck application when they add the action, allowing them to configure the action's settings. When `undefined`, the manifest's top-level `PropertyInspectorPath` is used, otherwise none. **NB.** Path should be relative to the root of the plugin's folder, with no leading slash.\n\n**Examples:**\n- mute.html\n- actions/join-voice-chat/settings.html"
+								"markdownDescription": "Optional path to the HTML file that represents the property inspector for this action; this is displayed to the user in the Stream Deck application when they add the action, allowing them to configure the action's settings. When `undefined`, the manifest's top-level `PropertyInspectorPath` is used, otherwise none.\n\nNB: Path should be relative to the root of the plugin's folder, with no leading slash.\n\n**Examples:**\n- mute.html\n- actions/join-voice-chat/settings.html"
 							},
 							"States": {
 								"type": "array",
@@ -133,13 +133,13 @@
 									"properties": {
 										"FontFamily": {
 											"type": "string",
-											"description": "Default font-family to be used when rendering the title of this state. **NB.** This can be overridden by the user in the Stream Deck application.",
-											"markdownDescription": "Default font-family to be used when rendering the title of this state. **NB.** This can be overridden by the user in the Stream Deck application."
+											"description": "Default font-family to be used when rendering the title of this state.\n\nNB: Can be overridden by the user in the Stream Deck application.",
+											"markdownDescription": "Default font-family to be used when rendering the title of this state.\n\nNB: Can be overridden by the user in the Stream Deck application."
 										},
 										"FontSize": {
 											"type": "number",
-											"description": "Default font-size to be used when rendering the title of this state. **NB.** This can be overridden by the user in the Stream Deck application.",
-											"markdownDescription": "Default font-size to be used when rendering the title of this state. **NB.** This can be overridden by the user in the Stream Deck application."
+											"description": "Default font-size to be used when rendering the title of this state.\n\nNB: Can be overridden by the user in the Stream Deck application.",
+											"markdownDescription": "Default font-size to be used when rendering the title of this state.\n\nNB: Can be overridden by the user in the Stream Deck application."
 										},
 										"FontStyle": {
 											"type": "string",
@@ -150,25 +150,25 @@
 												"Italic",
 												"Regular"
 											],
-											"description": "Default font-style to be used when rendering the title of this state. **NB.** This can be overridden by the user in the Stream Deck application.",
-											"markdownDescription": "Default font-style to be used when rendering the title of this state. **NB.** This can be overridden by the user in the Stream Deck application."
+											"description": "Default font-style to be used when rendering the title of this state.\n\nNB: Can be overridden by the user in the Stream Deck application.",
+											"markdownDescription": "Default font-style to be used when rendering the title of this state.\n\nNB: Can be overridden by the user in the Stream Deck application."
 										},
 										"FontUnderline": {
 											"type": "boolean",
-											"description": "Determines whether the title associated with this state is underlined by default. **NB.** This can be overridden by the user in the Stream Deck application.",
-											"markdownDescription": "Determines whether the title associated with this state is underlined by default. **NB.** This can be overridden by the user in the Stream Deck application."
+											"description": "Determines whether the title associated with this state is underlined by default.\n\nNB: Can be overridden by the user in the Stream Deck application.",
+											"markdownDescription": "Determines whether the title associated with this state is underlined by default.\n\nNB: Can be overridden by the user in the Stream Deck application."
 										},
 										"Image": {
 											"type": "string",
-											"description": "Path to the image, with the **file extension omitted**, that will be displayed on the Stream Deck when this action's state is active. The image must adhere to the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 72x72 px and 144x144 px (@2x).\n\n**NB.** This can be overridden by the user in the Stream Deck application.\n\n**Examples:**\n- assets/counter-key\n- assets/icons/mute",
+											"description": "Path to the image, with the **file extension omitted**, that will be displayed on the Stream Deck when this action's state is active. The image must adhere to the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 72x72 px and 144x144 px (@2x).\n\nNB: Can be overridden by the user in the Stream Deck application.\n\n**Examples:**\n- assets/counter-key\n- assets/icons/mute",
 											"pattern": "^[^.]+$",
-											"markdownDescription": "Path to the image, with the **file extension omitted**, that will be displayed on the Stream Deck when this action's state is active. The image must adhere to the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 72x72 px and 144x144 px (@2x).\n\n**NB.** This can be overridden by the user in the Stream Deck application.\n\n**Examples:**\n- assets/counter-key\n- assets/icons/mute"
+											"markdownDescription": "Path to the image, with the **file extension omitted**, that will be displayed on the Stream Deck when this action's state is active. The image must adhere to the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 72x72 px and 144x144 px (@2x).\n\nNB: Can be overridden by the user in the Stream Deck application.\n\n**Examples:**\n- assets/counter-key\n- assets/icons/mute"
 										},
 										"MultiActionImage": {
 											"type": "string",
-											"description": "Path to the image, with the **file extension omitted**, that will be displayed when the action is being viewed as part of a multi-action. The image must adhere to the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 72x72 px and 144x144 px (@2x).\n\n**NB.** This can be overridden by the user in the Stream Deck application.\n\n**Examples:**\n- assets/counter-key\n- assets/icons/mute",
+											"description": "Path to the image, with the **file extension omitted**, that will be displayed when the action is being viewed as part of a multi-action. The image must adhere to the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 72x72 px and 144x144 px (@2x).\n\nNB: Can be overridden by the user in the Stream Deck application.\n\n**Examples:**\n- assets/counter-key\n- assets/icons/mute",
 											"pattern": "^[^.]+$",
-											"markdownDescription": "Path to the image, with the **file extension omitted**, that will be displayed when the action is being viewed as part of a multi-action. The image must adhere to the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 72x72 px and 144x144 px (@2x).\n\n**NB.** This can be overridden by the user in the Stream Deck application.\n\n**Examples:**\n- assets/counter-key\n- assets/icons/mute"
+											"markdownDescription": "Path to the image, with the **file extension omitted**, that will be displayed when the action is being viewed as part of a multi-action. The image must adhere to the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 72x72 px and 144x144 px (@2x).\n\nNB: Can be overridden by the user in the Stream Deck application.\n\n**Examples:**\n- assets/counter-key\n- assets/icons/mute"
 										},
 										"Name": {
 											"type": "string",
@@ -177,8 +177,8 @@
 										},
 										"ShowTitle": {
 											"type": "boolean",
-											"description": "Determines whether the title should be shown. **NB.** This can be overridden by the user in the Stream Deck application.",
-											"markdownDescription": "Determines whether the title should be shown. **NB.** This can be overridden by the user in the Stream Deck application."
+											"description": "Determines whether the title should be shown.\n\nNB: Can be overridden by the user in the Stream Deck application.",
+											"markdownDescription": "Determines whether the title should be shown.\n\nNB: Can be overridden by the user in the Stream Deck application."
 										},
 										"Title": {
 											"type": "string",
@@ -192,14 +192,14 @@
 												"middle",
 												"top"
 											],
-											"description": "Default title alignment to be used when rendering the title of this state. **NB.** This can be overridden by the user in the Stream Deck application.",
-											"markdownDescription": "Default title alignment to be used when rendering the title of this state. **NB.** This can be overridden by the user in the Stream Deck application."
+											"description": "Default title alignment to be used when rendering the title of this state.\n\nNB: Can be overridden by the user in the Stream Deck application.",
+											"markdownDescription": "Default title alignment to be used when rendering the title of this state.\n\nNB: Can be overridden by the user in the Stream Deck application."
 										},
 										"TitleColor": {
 											"type": "string",
-											"description": "Default title color to be used when rendering the title of this state, represented a hexadecimal value. **NB.** This can be overridden by the user in the Stream Deck application.\n\n**Examples:**\n- #5bcefa\n- #f5a9b8\n- #FFFFFF",
+											"description": "Default title color to be used when rendering the title of this state, represented a hexadecimal value.\n\nNB: Can be overridden by the user in the Stream Deck application.\n\n**Examples:**\n- #5bcefa\n- #f5a9b8\n- #FFFFFF",
 											"pattern": "^#(?:[0-9a-fA-F]{3}){1,2}$",
-											"markdownDescription": "Default title color to be used when rendering the title of this state, represented a hexadecimal value. **NB.** This can be overridden by the user in the Stream Deck application.\n\n**Examples:**\n- #5bcefa\n- #f5a9b8\n- #FFFFFF"
+											"markdownDescription": "Default title color to be used when rendering the title of this state, represented a hexadecimal value.\n\nNB: Can be overridden by the user in the Stream Deck application.\n\n**Examples:**\n- #5bcefa\n- #f5a9b8\n- #FFFFFF"
 										}
 									},
 									"required": [
@@ -211,8 +211,8 @@
 								},
 								"minItems": 1,
 								"maxItems": 2,
-								"description": "States the action can be in. When two states are defined the action will act as a toggle, with users being able to select their preferred iconography for each state. **NB.** Automatic toggling of the state on action activation can be disabled by setting `DisableAutomaticStates` to `true`.",
-								"markdownDescription": "States the action can be in. When two states are defined the action will act as a toggle, with users being able to select their preferred iconography for each state. **NB.** Automatic toggling of the state on action activation can be disabled by setting `DisableAutomaticStates` to `true`."
+								"description": "States the action can be in. When two states are defined the action will act as a toggle, with users being able to select their preferred iconography for each state.\n\nNB: Automatic toggling of the state on action activation can be disabled by setting `DisableAutomaticStates` to `true`.",
+								"markdownDescription": "States the action can be in. When two states are defined the action will act as a toggle, with users being able to select their preferred iconography for each state.\n\nNB: Automatic toggling of the state on action activation can be disabled by setting `DisableAutomaticStates` to `true`."
 							},
 							"SupportedInMultiActions": {
 								"type": "boolean",
@@ -226,9 +226,9 @@
 							},
 							"UUID": {
 								"type": "string",
-								"description": "Unique identifier of the action, represented in reverse-DNS format. This value is supplied by Stream Deck when events are emitted that relate to the action enabling you to identify the source of the event. **NB.** This must be unique, and should be prefixed with the plugin's UUID.\n\n**Allowed characters:**\n- Lowercase alphanumeric characters (a-z, 0-9)\n- Hyphens (-)\n- Underscores (_)\n- Periods (.)\n\n**Examples:**\n- com.elgato.wavelink.toggle-mute\n- com.elgato.discord.join-voice\n- tv.twitch.go-live",
+								"description": "Unique identifier of the action, represented in reverse-DNS format. This value is supplied by Stream Deck when events are emitted that relate to the action enabling you to identify the source of the event.\n\n**Allowed characters:**\n- Lowercase alphanumeric characters (a-z, 0-9)\n- Hyphens (-)\n- Underscores (_)\n- Periods (.)\n\nNB: `UUID` must be unique, and should be prefixed with the plugin's UUID.\n\n\n**Examples:**\n- com.elgato.wavelink.toggle-mute\n- com.elgato.discord.join-voice\n- tv.twitch.go-live",
 								"pattern": "^([a-z0-9\\-_]*[a-z0-9][a-z0-9\\-_]*\\.){2,3}[a-z0-9\\-_]*[a-z0-9][a-z0-9\\-_]*$",
-								"markdownDescription": "Unique identifier of the action, represented in reverse-DNS format. This value is supplied by Stream Deck when events are emitted that relate to the action enabling you to identify the source of the event. **NB.** This must be unique, and should be prefixed with the plugin's UUID.\n\n**Allowed characters:**\n- Lowercase alphanumeric characters (a-z, 0-9)\n- Hyphens (-)\n- Underscores (_)\n- Periods (.)\n\n**Examples:**\n- com.elgato.wavelink.toggle-mute\n- com.elgato.discord.join-voice\n- tv.twitch.go-live"
+								"markdownDescription": "Unique identifier of the action, represented in reverse-DNS format. This value is supplied by Stream Deck when events are emitted that relate to the action enabling you to identify the source of the event.\n\n**Allowed characters:**\n- Lowercase alphanumeric characters (a-z, 0-9)\n- Hyphens (-)\n- Underscores (_)\n- Periods (.)\n\nNB: `UUID` must be unique, and should be prefixed with the plugin's UUID.\n\n\n**Examples:**\n- com.elgato.wavelink.toggle-mute\n- com.elgato.discord.join-voice\n- tv.twitch.go-live"
 							},
 							"UserTitleEnabled": {
 								"type": "boolean",
@@ -283,8 +283,8 @@
 				},
 				"Category": {
 					"type": "string",
-					"description": "Defines the actions list group, providing a natural grouping of the plugin's actions with the Stream Deck application's action list. **NB.** This should be distinctive and synonymous with your plugin, and it is therefore recommended that this be the same value as the plugin's `Name` field. When `undefined`, the actions will be available under the \"Custom\" group.",
-					"markdownDescription": "Defines the actions list group, providing a natural grouping of the plugin's actions with the Stream Deck application's action list. **NB.** This should be distinctive and synonymous with your plugin, and it is therefore recommended that this be the same value as the plugin's `Name` field. When `undefined`, the actions will be available under the \"Custom\" group."
+					"description": "Defines the actions list group, providing a natural grouping of the plugin's actions with the Stream Deck application's action list.\n\nNB: `Category` should be distinctive and synonymous with your plugin, and it is therefore recommended that this be the same value as the plugin's `Name` field. When `undefined`, the actions will be available under the \"Custom\" group.",
+					"markdownDescription": "Defines the actions list group, providing a natural grouping of the plugin's actions with the Stream Deck application's action list.\n\nNB: `Category` should be distinctive and synonymous with your plugin, and it is therefore recommended that this be the same value as the plugin's `Name` field. When `undefined`, the actions will be available under the \"Custom\" group."
 				},
 				"CategoryIcon": {
 					"type": "string",
@@ -344,12 +344,12 @@
 					"properties": {
 						"Debug": {
 							"type": "string",
-							"description": "Command-line arguments supplied to the plugin when run in debug mode. Optionally, the pre-defined values `\"enabled\"` and `\"break\"` run the plugin with a debugger enabled with [`--inspect`](https://nodejs.org/api/cli.html#--inspecthostport) and [`--inspect-brk`](https://nodejs.org/api/cli.html#--inspect-brkhostport) respectively. **NB.** `\"enabled\"` and `\"break\"` will automatically be assigned an available `PORT` by Stream Deck.  Alternatively, if you wish to debug on a pre-defined port, this value can be a set of [command-line arguments](https://nodejs.org/api/cli.html).\n\n**Examples:**\n- `\"enabled\"` results in `--inspect=127.0.0.1:{PORT}`\n- `\"break\"` results in `--inspect-brk=127.0.0.1:{PORT}`\n- `\"--inspect=127.0.0.1:12345\"` runs a local debugger on port `12345`.",
+							"description": "Command-line arguments supplied to the plugin when run in debug mode. Optionally, the pre-defined values `\"enabled\"` and `\"break\"` run the plugin with a debugger enabled with [`--inspect`](https://nodejs.org/api/cli.html#--inspecthostport) and [`--inspect-brk`](https://nodejs.org/api/cli.html#--inspect-brkhostport) respectively.\n\nNB: `\"enabled\"` and `\"break\"` will automatically be assigned an available `PORT` by Stream Deck.  Alternatively, if you wish to debug on a pre-defined port, this value can be a set of [command-line arguments](https://nodejs.org/api/cli.html).\n\n**Examples:**\n- `\"enabled\"` results in `--inspect=127.0.0.1:{PORT}`\n- `\"break\"` results in `--inspect-brk=127.0.0.1:{PORT}`\n- `\"--inspect=127.0.0.1:12345\"` runs a local debugger on port `12345`.",
 							"examples": [
 								"enabled",
 								"break"
 							],
-							"markdownDescription": "Command-line arguments supplied to the plugin when run in debug mode. Optionally, the pre-defined values `\"enabled\"` and `\"break\"` run the plugin with a debugger enabled with [`--inspect`](https://nodejs.org/api/cli.html#--inspecthostport) and [`--inspect-brk`](https://nodejs.org/api/cli.html#--inspect-brkhostport) respectively. **NB.** `\"enabled\"` and `\"break\"` will automatically be assigned an available `PORT` by Stream Deck.  Alternatively, if you wish to debug on a pre-defined port, this value can be a set of [command-line arguments](https://nodejs.org/api/cli.html).\n\n**Examples:**\n- `\"enabled\"` results in `--inspect=127.0.0.1:{PORT}`\n- `\"break\"` results in `--inspect-brk=127.0.0.1:{PORT}`\n- `\"--inspect=127.0.0.1:12345\"` runs a local debugger on port `12345`."
+							"markdownDescription": "Command-line arguments supplied to the plugin when run in debug mode. Optionally, the pre-defined values `\"enabled\"` and `\"break\"` run the plugin with a debugger enabled with [`--inspect`](https://nodejs.org/api/cli.html#--inspecthostport) and [`--inspect-brk`](https://nodejs.org/api/cli.html#--inspect-brkhostport) respectively.\n\nNB: `\"enabled\"` and `\"break\"` will automatically be assigned an available `PORT` by Stream Deck.  Alternatively, if you wish to debug on a pre-defined port, this value can be a set of [command-line arguments](https://nodejs.org/api/cli.html).\n\n**Examples:**\n- `\"enabled\"` results in `--inspect=127.0.0.1:{PORT}`\n- `\"break\"` results in `--inspect-brk=127.0.0.1:{PORT}`\n- `\"--inspect=127.0.0.1:12345\"` runs a local debugger on port `12345`."
 						},
 						"GenerateProfilerOutput": {
 							"type": "boolean",
@@ -367,8 +367,8 @@
 						"Version"
 					],
 					"additionalProperties": false,
-					"description": "Configuration options for Node.js based plugins. **NB.** All Node.js plugins are executed with the following command-line arguments [`--no-addons`](https://nodejs.org/api/cli.html#--no-addons), [`--enable-source-maps`](https://nodejs.org/api/cli.html#--enable-source-maps), and [`--no-global-search-paths`](https://nodejs.org/api/cli.html#--no-global-search-paths).",
-					"markdownDescription": "Configuration options for Node.js based plugins. **NB.** All Node.js plugins are executed with the following command-line arguments [`--no-addons`](https://nodejs.org/api/cli.html#--no-addons), [`--enable-source-maps`](https://nodejs.org/api/cli.html#--enable-source-maps), and [`--no-global-search-paths`](https://nodejs.org/api/cli.html#--no-global-search-paths)."
+					"description": "Configuration options for Node.js based plugins.\n\nNB: All Node.js plugins are executed with the following command-line arguments:\n\n- [`--no-addons`](https://nodejs.org/api/cli.html#--no-addons) (Stream Deck 6.4 only)\n- [`--enable-source-maps`](https://nodejs.org/api/cli.html#--enable-source-maps)\n- [`--no-global-search-paths`](https://nodejs.org/api/cli.html#--no-global-search-paths)",
+					"markdownDescription": "Configuration options for Node.js based plugins.\n\nNB: All Node.js plugins are executed with the following command-line arguments:\n\n- [`--no-addons`](https://nodejs.org/api/cli.html#--no-addons) (Stream Deck 6.4 only)\n- [`--enable-source-maps`](https://nodejs.org/api/cli.html#--enable-source-maps)\n- [`--no-global-search-paths`](https://nodejs.org/api/cli.html#--no-global-search-paths)"
 				},
 				"OS": {
 					"type": "array",
@@ -435,14 +435,14 @@
 						],
 						"additionalProperties": false
 					},
-					"description": "Collection of pre-defined profiles that are distributed with this plugin. Upon installation of the plugin, the user will be prompted to install the profiles. Once installed, the plugin can switch any of the pre-defined profiles. **NB.** It is not yet possible to switch to a user-defined profile.\n\n**Also see:** `streamDeck.profiles.switchToProfile(...)`",
-					"markdownDescription": "Collection of pre-defined profiles that are distributed with this plugin. Upon installation of the plugin, the user will be prompted to install the profiles. Once installed, the plugin can switch any of the pre-defined profiles. **NB.** It is not yet possible to switch to a user-defined profile.\n\n**Also see:** `streamDeck.profiles.switchToProfile(...)`"
+					"description": "Collection of pre-defined profiles that are distributed with this plugin. Upon the plugin switching to the profile, the user will be prompted to install the profiles.\n\nNB: Plugins may only switch to profiles distributed with the plugin, as defined within the manifest, and cannot access user-defined profiles.\n\n**Also see:** `streamDeck.profiles.switchToProfile(...)`",
+					"markdownDescription": "Collection of pre-defined profiles that are distributed with this plugin. Upon the plugin switching to the profile, the user will be prompted to install the profiles.\n\nNB: Plugins may only switch to profiles distributed with the plugin, as defined within the manifest, and cannot access user-defined profiles.\n\n**Also see:** `streamDeck.profiles.switchToProfile(...)`"
 				},
 				"PropertyInspectorPath": {
 					"type": "string",
-					"description": "Optional path to the HTML file that represents the property inspector for all actions; this is displayed to the user in the Stream Deck application when they add an action, allowing them to configure the action's settings. **NB.** Path should be relative to the root of the plugin's folder, with no leading slash.\n\n **Examples:**\n- mute.html\n- actions/join-voice-chat/settings.html\n\n**Also see:**\n- `streamDeck.ui.onSendToPlugin(...)`",
+					"description": "Optional path to the HTML file that represents the property inspector for all actions; this is displayed to the user in the Stream Deck application when they add an action, allowing them to configure the action's settings.\n\nNB: Path should be relative to the root of the plugin's folder, with no leading slash.\n\n **Examples:**\n- mute.html\n- actions/join-voice-chat/settings.html\n\n**Also see:**\n- `streamDeck.ui.onSendToPlugin(...)`",
 					"pattern": "^(?!\\/).+\\.[Hh][Tt][Mm][Ll]?$",
-					"markdownDescription": "Optional path to the HTML file that represents the property inspector for all actions; this is displayed to the user in the Stream Deck application when they add an action, allowing them to configure the action's settings. **NB.** Path should be relative to the root of the plugin's folder, with no leading slash.\n\n **Examples:**\n- mute.html\n- actions/join-voice-chat/settings.html\n\n**Also see:**\n- `streamDeck.ui.onSendToPlugin(...)`"
+					"markdownDescription": "Optional path to the HTML file that represents the property inspector for all actions; this is displayed to the user in the Stream Deck application when they add an action, allowing them to configure the action's settings.\n\nNB: Path should be relative to the root of the plugin's folder, with no leading slash.\n\n **Examples:**\n- mute.html\n- actions/join-voice-chat/settings.html\n\n**Also see:**\n- `streamDeck.ui.onSendToPlugin(...)`"
 				},
 				"SDKVersion": {
 					"type": "number",
@@ -477,11 +477,11 @@
 				},
 				"Version": {
 					"type": "string",
-					"description": "Version of the plugin, represented as a  {@link  https://semver.org semantic version } . **NB.** pre-release values are not currently supported.\n\n**Examples:**\n- 1.0.3 ✅\n- 0.0.99 ✅\n- 2.1.9-beta1 ❌",
+					"description": "Version of the plugin, represented as a  {@link  https://semver.org semantic version }  (excluding pre-release values).\n\n**Examples:**\n- 1.0.3 ✅\n- 0.0.99 ✅\n- 2.1.9-beta1 ❌",
 					"examples": [
 						"1.0.0"
 					],
-					"markdownDescription": "Version of the plugin, represented as a  {@link  https://semver.org semantic version } . **NB.** pre-release values are not currently supported.\n\n**Examples:**\n- 1.0.3 ✅\n- 0.0.99 ✅\n- 2.1.9-beta1 ❌"
+					"markdownDescription": "Version of the plugin, represented as a  {@link  https://semver.org semantic version }  (excluding pre-release values).\n\n**Examples:**\n- 1.0.3 ✅\n- 0.0.99 ✅\n- 2.1.9-beta1 ❌"
 				}
 			},
 			"required": [

--- a/src/actions/action.ts
+++ b/src/actions/action.ts
@@ -136,9 +136,11 @@ export class Action<T extends PayloadObject<T> = object> {
 	}
 
 	/**
-	 * Sets the {@link image} to be display for this action instance. **NB** This will be ignored if the user has chosen a custom image within the Stream Deck application.
+	 * Sets the {@link image} to be display for this action instance.
+	 *
+	 * NB: The image can only be set by the plugin when the the user has not specified a custom image.
 	 * @param image Image to display; this can be either a path to a local file within the plugin's folder, a base64 encoded `string` with the mime type declared (e.g. PNG, JPEG, etc.),
-	 * or an SVG `string`. When {@link image} is `undefined`, the image from the manifest is used.
+	 * or an SVG `string`. When `undefined`, the image from the manifest will be used.
 	 * @param options Additional options that define where and how the image should be rendered.
 	 * @returns `Promise` resolved when the request to set the {@link image} has been sent to Stream Deck.
 	 */
@@ -183,7 +185,9 @@ export class Action<T extends PayloadObject<T> = object> {
 
 	/**
 	 * Sets the {@link title} displayed for this action instance. See also {@link SingletonAction.onTitleParametersDidChange}.
-	 * @param title Title to display; when undefined the title within the manifest will be used. **NB.** the title will only be set if the user has not specified a custom title.
+	 *
+	 * NB: The title can only be set by the plugin when the the user has not specified a custom title.
+	 * @param title Title to display; when `undefined` the title within the manifest will be used.
 	 * @param options Additional options that define where and how the title should be rendered.
 	 * @returns `Promise` resolved when the request to set the {@link title} has been sent to Stream Deck.
 	 */
@@ -201,7 +205,9 @@ export class Action<T extends PayloadObject<T> = object> {
 	/**
 	 * Sets the trigger (interaction) {@link descriptions} associated with this action instance. Descriptions are shown within the Stream Deck application, and informs the user what
 	 * will happen when they interact with the action, e.g. rotate, touch, etc. When {@link descriptions} is `undefined`, the descriptions will be reset to the values provided as part
-	 * of the manifest. **NB** only applies to encoders as part of Stream Deck+ (dials / touchscreens).
+	 * of the manifest.
+	 *
+	 * NB: Applies to encoders (dials / touchscreens) found on Stream Deck+ devices.
 	 * @param descriptions Descriptions that detail the action's interaction.
 	 * @returns `Promise` resolved when the request to set the {@link descriptions} has been sent to Stream Deck.
 	 */

--- a/src/actions/client.ts
+++ b/src/actions/client.ts
@@ -61,7 +61,9 @@ export class ActionClient {
 	}
 
 	/**
-	 * Occurs when the user presses a dial (Stream Deck+). **NB** For other action types see {@link ActionClient.onKeyDown}. Also see {@link ActionClient.onDialUp}.
+	 * Occurs when the user presses a dial (Stream Deck+). Also see {@link ActionClient.onDialUp}.
+	 *
+	 * NB: For other action types see {@link ActionClient.onKeyDown}.
 	 * @template T The type of settings associated with the action.
 	 * @param listener Function to be invoked when the event occurs.
 	 * @returns A disposable that, when disposed, removes the listener.
@@ -81,7 +83,9 @@ export class ActionClient {
 	}
 
 	/**
-	 * Occurs when the user releases a pressed dial (Stream Deck+). **NB** For other action types see {@link ActionClient.onKeyUp}. Also see {@link ActionClient.onDialDown}.
+	 * Occurs when the user releases a pressed dial (Stream Deck+). Also see {@link ActionClient.onDialDown}.
+	 *
+	 * NB: For other action types see {@link ActionClient.onKeyUp}.
 	 * @template T The type of settings associated with the action.
 	 * @param listener Function to be invoked when the event occurs.
 	 * @returns A disposable that, when disposed, removes the listener.
@@ -91,7 +95,9 @@ export class ActionClient {
 	}
 
 	/**
-	 * Occurs when the user presses a action down. **NB** For dials / touchscreens see {@link ActionClient.onDialDown}. Also see {@link ActionClient.onKeyUp}.
+	 * Occurs when the user presses a action down. Also see {@link ActionClient.onKeyUp}.
+	 *
+	 * NB: For dials / touchscreens see {@link ActionClient.onDialDown}.
 	 * @template T The type of settings associated with the action.
 	 * @param listener Function to be invoked when the event occurs.
 	 * @returns A disposable that, when disposed, removes the listener.
@@ -101,7 +107,9 @@ export class ActionClient {
 	}
 
 	/**
-	 * Occurs when the user releases a pressed action. **NB** For dials / touchscreens see {@link ActionClient.onDialUp}. Also see {@link ActionClient.onKeyDown}.
+	 * Occurs when the user releases a pressed action. Also see {@link ActionClient.onKeyDown}.
+	 *
+	 * NB: For dials / touchscreens see {@link ActionClient.onDialUp}.
 	 * @template T The type of settings associated with the action.
 	 * @param listener Function to be invoked when the event occurs.
 	 * @returns A disposable that, when disposed, removes the listener.

--- a/src/actions/singleton-action.ts
+++ b/src/actions/singleton-action.ts
@@ -29,7 +29,9 @@ export class SingletonAction<T extends PayloadObject<T> = object> {
 	public readonly manifestId: string | undefined;
 
 	/**
-	 * Occurs when the user presses a dial (Stream Deck+). **NB** For other action types see {@link ActionClient.onKeyDown}. Also see {@link ActionClient.onDialUp}.
+	 * Occurs when the user presses a dial (Stream Deck+). Also see {@link ActionClient.onDialUp}.
+	 *
+	 * NB: For other action types see {@link ActionClient.onKeyDown}.
 	 * @param listener Function to be invoked when the event occurs.
 	 */
 	public onDialDown?(ev: DialDownEvent<T>): Promise<void> | void;
@@ -41,7 +43,9 @@ export class SingletonAction<T extends PayloadObject<T> = object> {
 	public onDialRotate?(ev: DialRotateEvent<T>): Promise<void> | void;
 
 	/**
-	 * Occurs when the user releases a pressed dial (Stream Deck+). **NB** For other action types see {@link ActionClient.onKeyUp}. Also see {@link ActionClient.onDialDown}.
+	 * Occurs when the user releases a pressed dial (Stream Deck+). Also see {@link ActionClient.onDialDown}.
+	 *
+	 * NB: For other action types see {@link ActionClient.onKeyUp}.
 	 * @param listener Function to be invoked when the event occurs.
 	 */
 	public onDialUp?(ev: DialUpEvent<T>): Promise<void> | void;
@@ -53,13 +57,17 @@ export class SingletonAction<T extends PayloadObject<T> = object> {
 	public onDidReceiveSettings?(ev: DidReceiveSettingsEvent<T>): Promise<void> | void;
 
 	/**
-	 * Occurs when the user presses a action down. **NB** For dials / touchscreens see {@link ActionClient.onDialDown}. Also see {@link ActionClient.onKeyUp}.
+	 * Occurs when the user presses a action down. Also see {@link ActionClient.onKeyUp}.
+	 *
+	 * NB: For dials / touchscreens see {@link ActionClient.onDialDown}.
 	 * @param listener Function to be invoked when the event occurs.
 	 */
 	public onKeyDown?(ev: KeyDownEvent<T>): Promise<void> | void;
 
 	/**
-	 * Occurs when the user releases a pressed action. **NB** For dials / touchscreens see {@link ActionClient.onDialUp}. Also see {@link ActionClient.onKeyDown}.
+	 * Occurs when the user releases a pressed action. Also see {@link ActionClient.onKeyDown}.
+	 *
+	 * NB: For dials / touchscreens see {@link ActionClient.onDialUp}.
 	 * @param listener Function to be invoked when the event occurs.
 	 */
 	public onKeyUp?(ev: KeyUpEvent<T>): Promise<void> | void;

--- a/src/common/version.ts
+++ b/src/common/version.ts
@@ -1,7 +1,9 @@
 /**
  * Provides information for a version, as parsed from a string denoted as a collection of numbers separated by a period, for example `1.45.2`, `4.0.2.13098`. Parsing is opinionated
  * and strings should strictly conform to the format `{major}[.{minor}[.{patch}[.{build}]]]`; version numbers that form the version are optional, and when `undefined` will default to
- * 0, for example the `minor`, `patch`, or `build` number may be omitted. **NB** This implementation should be considered fit-for-purpose, and should be used sparing.
+ * 0, for example the `minor`, `patch`, or `build` number may be omitted.
+ *
+ * NB: This implementation should be considered fit-for-purpose, and should be used sparing.
  */
 export class Version {
 	/**

--- a/src/connectivity/commands.ts
+++ b/src/connectivity/commands.ts
@@ -196,8 +196,9 @@ export type SetTriggerDescription = ContextualizedCommand<
 >;
 
 /**
- * Switches the pre-defined profile on the specified device. **NB**, plugins can only switch to profiles included as part of the plugin and defined within the manifest, and cannot
- * switch to custom profiles created by users.
+ * Switches to the profile, as distributed by the plugin, on the specified device.
+ *
+ * NB: Plugins may only switch to profiles distributed with the plugin, as defined within the manifest, and cannot access user-defined profiles.
  */
 export type SwitchToProfile = ContextualizedCommand<
 	"switchToProfile",

--- a/src/connectivity/device-info.ts
+++ b/src/connectivity/device-info.ts
@@ -8,7 +8,7 @@ export type DeviceInfo = {
 	readonly name: string;
 
 	/**
-	 * Number of action slots available to the device. NB. The size denotes keys only.
+	 * Number of action slots, excluding dials / touchscreens, available to the device.
 	 */
 	readonly size: Size;
 

--- a/src/connectivity/events/action.ts
+++ b/src/connectivity/events/action.ts
@@ -135,7 +135,7 @@ export type MultiActionPayload<TSettings extends PayloadObject<TSettings>> = Act
 	 * Defines the controller type the action is applicable to. **Keypad** refers to a standard action on a Stream Deck device, e.g. 1 of the 15 buttons on the Stream Deck MK.2,
 	 * or a pedal on the Stream Deck Pedal, etc., whereas an **Encoder** refers to a dial / touchscreen on the Stream Deck+.
 	 *
-	 * **NB.** Requires Stream Deck 6.5 for `WillAppear` and `WillDisappear` events.
+	 * NB: Requires Stream Deck 6.5 for `WillAppear` and `WillDisappear` events.
 	 */
 	readonly controller: "Keypad";
 

--- a/src/connectivity/events/encoder.ts
+++ b/src/connectivity/events/encoder.ts
@@ -1,13 +1,18 @@
 import type { ActionEventMessage, Coordinates, SingleActionPayload } from "./action";
 import type { PayloadObject } from "./index";
+import type { KeyDown, KeyUp } from "./keypad";
 
 /**
- * Occurs when the user presses a dial (Stream Deck+).
+ * Occurs when the user presses a dial (Stream Deck+).Also see {@link DialUp}.
+ *
+ * NB: For other action types see {@link KeyDown}.
  */
 export type DialDown<TSettings extends PayloadObject<TSettings>> = ActionEventMessage<"dialDown", EncoderPayload<TSettings>>;
 
 /**
- * Occurs when the user releases a pressed dial (Stream Deck+).
+ * Occurs when the user releases a pressed dial (Stream Deck+).Also see {@link DialDown}.
+ *
+ * NB: For other action types see {@link KeyUp}.
  */
 export type DialUp<TSettings extends PayloadObject<TSettings>> = ActionEventMessage<"dialUp", EncoderPayload<TSettings>>;
 

--- a/src/connectivity/events/keypad.ts
+++ b/src/connectivity/events/keypad.ts
@@ -3,12 +3,16 @@ import type { DialDown, DialUp } from "./encoder";
 import type { PayloadObject } from "./index";
 
 /**
- * Occurs when the user presses a action down. **NB** For dials / touchscreens see {@link DialDown}. Also see {@link KeyUp}.
+ * Occurs when the user presses a action down. Also see {@link KeyUp}.
+ *
+ * NB: For dials / touchscreens see {@link DialDown}.
  */
 export type KeyDown<TSettings extends PayloadObject<TSettings>> = ActionEventMessage<"keyDown", KeypadPayload<TSettings>>;
 
 /**
- * Occurs when the user releases a pressed action. **NB** For dials / touchscreens see {@link DialUp}. Also see {@link KeyDown}.
+ * Occurs when the user releases a pressed action. Also see {@link KeyDown}.
+ *
+ * NB: For dials / touchscreens see {@link DialUp}.
  */
 export type KeyUp<TSettings extends PayloadObject<TSettings>> = ActionEventMessage<"keyUp", KeypadPayload<TSettings>>;
 

--- a/src/connectivity/layouts.ts
+++ b/src/connectivity/layouts.ts
@@ -52,8 +52,8 @@ type LayoutItemDefinition<TType extends string, TItem> = TItem & {
  */
 type LayoutItem = {
 	/**
-	 * Background color represented as a named color, hexadecimal value, or gradient. **NB** Gradients can be defined by specifying multiple color-stops separated by commas, in the
-	 * following format `[{offset}:{color}[,]]`.
+	 * Background color represented as a named color, hexadecimal value, or gradient. Gradients can be defined by specifying multiple color-stops separated by commas, in the following
+	 * format `[{offset}:{color}[,]]`.
 	 *
 	 * **Examples:**
 	 * - "pink"
@@ -99,8 +99,8 @@ export type Pixmap = LayoutItem & {
  */
 export type Bar = LayoutItem & {
 	/**
-	 * Bar background color represented as a named color, hexadecimal value, or gradient. Default is `darkGray`. **NB** Gradients can be defined by specifying multiple color-stops
-	 * separated by commas, in the following format `[{offset}:{color}[,]]`.
+	 * Bar background color represented as a named color, hexadecimal value, or gradient. Default is `darkGray`. Gradients can be defined by specifying multiple color-stops separated
+	 * by commas, in the following format `[{offset}:{color}[,]]`.
 	 *
 	 * **Examples:**
 	 * - "pink"
@@ -123,7 +123,7 @@ export type Bar = LayoutItem & {
 	bar_border_c?: string;
 
 	/**
-	 * Fill color of the bar represented as a named color, hexadecimal value, or gradient. Default is `white`. **NB** Gradients can be defined by specifying multiple color-stops separated
+	 * Fill color of the bar represented as a named color, hexadecimal value, or gradient. Default is `white`. Gradients can be defined by specifying multiple color-stops separated
 	 * by commas, in the following format `[{offset}:{color}[,]]`.
 	 *
 	 * **Examples:**

--- a/src/connectivity/layouts.ts
+++ b/src/connectivity/layouts.ts
@@ -158,9 +158,16 @@ export type Bar = LayoutItem & {
 	};
 
 	/**
-	 * Sub-type used to determine the type of bar to render. Default is {@link BarSubType.Groove}.
+	 * Sub-type used to determine the type of bar to render. Default is {@link BarSubType.Groove} (4).
+	 *
+	 * **Options**
+	 * - Rectangle (0)
+	 * - DoubleRectangle (1)
+	 * - Trapezoid (2)
+	 * - DoubleTrapezoid (3)
+	 * - Groove (4)
 	 */
-	subtype?: BarSubType;
+	subtype?: (typeof BarSubType)[keyof typeof BarSubType];
 
 	/**
 	 * Value used to determine how much of the bar is filled. Correlates with the item's `range` if specified in the layout's JSON definition; default range is `0..100`.

--- a/src/connectivity/layouts.ts
+++ b/src/connectivity/layouts.ts
@@ -227,7 +227,7 @@ export type Text = LayoutItem & {
 	 * - clip, truncates the text at the boundary of the element (default).
 	 * - ellipsis, truncates the text prior to the boundary of the element, and adds an ellipsis (…) to the end.
 	 * - fade, applies a fade-gradient over the end of the text.
-	 * @default clip
+	 * @default ellipsis
 	 */
 	"text-overflow"?: "clip" | "ellipsis" | "fade";
 

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -95,7 +95,7 @@ export class Logger {
 	}
 
 	/**
-	 * Sets the log-level that determines which logs should be written. **NB.** this level will be inherited by all scoped loggers unless they have log-level explicitly defined.
+	 * Sets the log-level that determines which logs should be written. The specified level will be inherited by all scoped loggers unless they have log-level explicitly defined.
 	 * @param level The log-level that determines which logs should be written; when `undefined`, the level will be inherited from the parent logger, or default to the environment level.
 	 * @returns This instance for chaining.
 	 */

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -57,7 +57,7 @@ export type Manifest = {
 			 * - assets/actions/mute/encoder-icon
 			 * - imgs/join-voice-chat-encoder
 			 */
-			Icon?: ImageFilePathWithoutExtension;
+			Icon?: FilePathWithoutExtension;
 
 			/**
 			 * Background color to display in the Stream Deck application when the action is part of a dial stack, and is the current action. Represented as a hexadecimal value.
@@ -112,7 +112,7 @@ export type Manifest = {
 			 * - assets/backgrounds/main
 			 * - imgs/bright-blue-bg
 			 */
-			background?: ImageFilePathWithoutExtension;
+			background?: FilePathWithoutExtension;
 
 			/**
 			 * Name of a pre-defined layout, or the path to a JSON file that details a custom layout and its components, to be rendered on the action's touchscreen canvas.
@@ -147,7 +147,7 @@ export type Manifest = {
 		 * - assets/counter
 		 * - imgs/actions/mute
 		 */
-		Icon: ImageFilePathWithoutExtension;
+		Icon: FilePathWithoutExtension;
 
 		/**
 		 * Name of the action; this is displayed to the user in the actions list, and is used throughout the Stream Deck application to visually identify the action.
@@ -261,7 +261,7 @@ export type Manifest = {
 	 * - assets/category-icon
 	 * - imgs/category
 	 */
-	CategoryIcon?: ImageFilePathWithoutExtension;
+	CategoryIcon?: FilePathWithoutExtension;
 
 	/**
 	 * Path to the plugin's main entry point; this is executed when the Stream Deck application starts the plugin.
@@ -313,7 +313,7 @@ export type Manifest = {
 	 * assets/plugin-icon
 	 * imgs/plugin
 	 */
-	Icon: ImageFilePathWithoutExtension;
+	Icon: FilePathWithoutExtension;
 
 	/**
 	 * Name of the plugin, e.g. "Wave Link", "Camera Hub", "Control Center", etc.
@@ -449,11 +449,11 @@ export type Manifest = {
 type HtmlFilePath = FilePath<"htm" | "html">;
 
 /**
- * File path that represents an image file relative to the plugin's manifest.
+ * File path that represents a file relative to the plugin's manifest, with the extension omitted.
  * @pattern
- * ^(?!\/).+(?<!\.([Pp][Nn][Gg]|[Ss][Vv][Gg]))$
+ * ^[^.]+$
  */
-type ImageFilePathWithoutExtension = string;
+type FilePathWithoutExtension = string;
 
 /**
  * File path, relative to the manifest's location.
@@ -511,7 +511,7 @@ type ActionState = {
 	 * - assets/counter-key
 	 * - assets/icons/mute
 	 */
-	Image: ImageFilePathWithoutExtension;
+	Image: FilePathWithoutExtension;
 
 	/**
 	 * Path to the image, with the **file extension omitted**, that will be displayed when the action is being viewed as part of a multi-action. The image must adhere to the following
@@ -525,7 +525,7 @@ type ActionState = {
 	 * - assets/counter-key
 	 * - assets/icons/mute
 	 */
-	MultiActionImage?: ImageFilePathWithoutExtension;
+	MultiActionImage?: FilePathWithoutExtension;
 
 	/**
 	 * Name of the state; when multiple states are defined this value is shown to the user when the action is being added to a multi-action. The user is then able to specify which

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -380,9 +380,19 @@ export type Manifest = {
 	 */
 	Profiles?: {
 		/**
-		 * Type of device the profile is applicable too, e.g. Stream Deck+, Stream Deck Pedal, etc.
+		 * Type of device the profile is intended for, for example Stream Deck+, Stream Deck Pedal, etc.
+		 *
+		 * **Devices**
+		 * - Stream Deck (0)
+		 * - Stream Deck Mini (1)
+		 * - Stream Deck XL (2)
+		 * - Stream Deck Mobile (3)
+		 * - Corsair GKeys (4)
+		 * - Stream Deck Pedal (5)
+		 * - Corsair Voyager (6)
+		 * - Stream Deck Plus (7)
 		 */
-		DeviceType: DeviceType;
+		DeviceType: (typeof DeviceType)[keyof typeof DeviceType];
 
 		/**
 		 * Determines whether the Stream Deck application should automatically switch to the profile when it is first installed. Default value is `false`.

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -51,7 +51,7 @@ export type Manifest = {
 			 * - Be in .PNG or .SVG format.
 			 * - Be provided in two sizes, 72x72 px and 144x144 px (@2x).
 			 *
-			 * **NB.** This can be overridden by the user in the Stream Deck application.
+			 * NB: Can be overridden by the user in the Stream Deck application.
 			 *
 			 * **Examples:**
 			 * - assets/actions/mute/encoder-icon
@@ -106,7 +106,7 @@ export type Manifest = {
 			 * - Be in .PNG or .SVG format.
 			 * - Be provided in two sizes, 200x100 px and 400x200 px (@2x).
 			 *
-			 * **NB.** This can be overridden by the user in the Stream Deck application
+			 * NB: Can be overridden by the user in the Stream Deck application.
 			 *
 			 * **Examples:**
 			 * - assets/backgrounds/main
@@ -156,8 +156,9 @@ export type Manifest = {
 
 		/**
 		 * Optional path to the HTML file that represents the property inspector for this action; this is displayed to the user in the Stream Deck application when they add the
-		 * action, allowing them to configure the action's settings. When `undefined`, the manifest's top-level `PropertyInspectorPath` is used, otherwise none. **NB.** Path should be
-		 * relative to the root of the plugin's folder, with no leading slash.
+		 * action, allowing them to configure the action's settings. When `undefined`, the manifest's top-level `PropertyInspectorPath` is used, otherwise none.
+		 *
+		 * NB: Path should be relative to the root of the plugin's folder, with no leading slash.
 		 *
 		 * **Examples:**
 		 * - mute.html
@@ -166,8 +167,9 @@ export type Manifest = {
 		PropertyInspectorPath?: HtmlFilePath;
 
 		/**
-		 * States the action can be in. When two states are defined the action will act as a toggle, with users being able to select their preferred iconography for each state. **NB.**
-		 * Automatic toggling of the state on action activation can be disabled by setting `DisableAutomaticStates` to `true`.
+		 * States the action can be in. When two states are defined the action will act as a toggle, with users being able to select their preferred iconography for each state.
+		 *
+		 * NB: Automatic toggling of the state on action activation can be disabled by setting `DisableAutomaticStates` to `true`.
 		 */
 		States: [ActionState, ActionState?];
 
@@ -183,13 +185,16 @@ export type Manifest = {
 
 		/**
 		 * Unique identifier of the action, represented in reverse-DNS format. This value is supplied by Stream Deck when events are emitted that relate to the action enabling you
-		 * to identify the source of the event. **NB.** This must be unique, and should be prefixed with the plugin's UUID.
+		 * to identify the source of the event.
 		 *
 		 * **Allowed characters:**
 		 * - Lowercase alphanumeric characters (a-z, 0-9)
 		 * - Hyphens (-)
 		 * - Underscores (_)
 		 * - Periods (.)
+		 *
+		 * NB: `UUID` must be unique, and should be prefixed with the plugin's UUID.
+		 *
 		 *
 		 * **Examples:**
 		 * - com.elgato.wavelink.toggle-mute
@@ -244,9 +249,10 @@ export type Manifest = {
 	Author: string;
 
 	/**
-	 * Defines the actions list group, providing a natural grouping of the plugin's actions with the Stream Deck application's action list. **NB.** This should be distinctive and
-	 * synonymous with your plugin, and it is therefore recommended that this be the same value as the plugin's `Name` field. When `undefined`, the actions will be available under
-	 * the "Custom" group.
+	 * Defines the actions list group, providing a natural grouping of the plugin's actions with the Stream Deck application's action list.
+	 *
+	 * NB: `Category` should be distinctive and synonymous with your plugin, and it is therefore recommended that this be the same value as the plugin's `Name` field. When `undefined`, the
+	 * actions will be available under the "Custom" group.
 	 */
 	Category?: string;
 
@@ -321,14 +327,20 @@ export type Manifest = {
 	Name: string;
 
 	/**
-	 * Configuration options for Node.js based plugins. **NB.** All Node.js plugins are executed with the following command-line arguments [`--no-addons`](https://nodejs.org/api/cli.html#--no-addons),
-	 * [`--enable-source-maps`](https://nodejs.org/api/cli.html#--enable-source-maps), and [`--no-global-search-paths`](https://nodejs.org/api/cli.html#--no-global-search-paths).
+	 * Configuration options for Node.js based plugins.
+	 *
+	 * NB: All Node.js plugins are executed with the following command-line arguments:
+	 *
+	 * - [`--no-addons`](https://nodejs.org/api/cli.html#--no-addons) (Stream Deck 6.4 only)
+	 * - [`--enable-source-maps`](https://nodejs.org/api/cli.html#--enable-source-maps)
+	 * - [`--no-global-search-paths`](https://nodejs.org/api/cli.html#--no-global-search-paths)
 	 */
 	Nodejs?: {
 		/**
 		 * Command-line arguments supplied to the plugin when run in debug mode. Optionally, the pre-defined values `"enabled"` and `"break"` run the plugin with a debugger enabled
-		 * with [`--inspect`](https://nodejs.org/api/cli.html#--inspecthostport) and [`--inspect-brk`](https://nodejs.org/api/cli.html#--inspect-brkhostport) respectively. **NB.**
-		 * `"enabled"` and `"break"` will automatically be assigned an available `PORT` by Stream Deck.  Alternatively, if you wish to debug on a pre-defined port, this value can be
+		 * with [`--inspect`](https://nodejs.org/api/cli.html#--inspecthostport) and [`--inspect-brk`](https://nodejs.org/api/cli.html#--inspect-brkhostport) respectively.
+		 *
+		 * NB: `"enabled"` and `"break"` will automatically be assigned an available `PORT` by Stream Deck.  Alternatively, if you wish to debug on a pre-defined port, this value can be
 		 * a set of [command-line arguments](https://nodejs.org/api/cli.html).
 		 *
 		 * **Examples:**
@@ -359,8 +371,9 @@ export type Manifest = {
 	OS: [OS, OS?];
 
 	/**
-	 * Collection of pre-defined profiles that are distributed with this plugin. Upon installation of the plugin, the user will be prompted to install the profiles. Once installed,
-	 * the plugin can switch any of the pre-defined profiles. **NB.** It is not yet possible to switch to a user-defined profile.
+	 * Collection of pre-defined profiles that are distributed with this plugin. Upon the plugin switching to the profile, the user will be prompted to install the profiles.
+	 *
+	 * NB: Plugins may only switch to profiles distributed with the plugin, as defined within the manifest, and cannot access user-defined profiles.
 	 *
 	 * **Also see:**
 	 * `streamDeck.profiles.switchToProfile(...)`
@@ -393,7 +406,9 @@ export type Manifest = {
 
 	/**
 	 * Optional path to the HTML file that represents the property inspector for all actions; this is displayed to the user in the Stream Deck application when they add an action,
-	 * allowing them to configure the action's settings. **NB.** Path should be relative to the root of the plugin's folder, with no leading slash.
+	 * allowing them to configure the action's settings.
+	 *
+	 * NB: Path should be relative to the root of the plugin's folder, with no leading slash.
 	 *
 	 *  **Examples:**
 	 * - mute.html
@@ -429,7 +444,7 @@ export type Manifest = {
 	URL?: string;
 
 	/**
-	 * Version of the plugin, represented as a {@link https://semver.org semantic version}. **NB.** pre-release values are not currently supported.
+	 * Version of the plugin, represented as a {@link https://semver.org semantic version} (excluding pre-release values).
 	 *
 	 * **Examples:**
 	 * - 1.0.3 ✅
@@ -480,22 +495,30 @@ type OS = {
  */
 type ActionState = {
 	/**
-	 * Default font-family to be used when rendering the title of this state. **NB.** This can be overridden by the user in the Stream Deck application.
+	 * Default font-family to be used when rendering the title of this state.
+	 *
+	 * NB: Can be overridden by the user in the Stream Deck application.
 	 */
 	FontFamily?: string;
 
 	/**
-	 * Default font-size to be used when rendering the title of this state. **NB.** This can be overridden by the user in the Stream Deck application.
+	 * Default font-size to be used when rendering the title of this state.
+	 *
+	 * NB: Can be overridden by the user in the Stream Deck application.
 	 */
 	FontSize?: number;
 
 	/**
-	 * Default font-style to be used when rendering the title of this state. **NB.** This can be overridden by the user in the Stream Deck application.
+	 * Default font-style to be used when rendering the title of this state.
+	 *
+	 * NB: Can be overridden by the user in the Stream Deck application.
 	 */
 	FontStyle?: "" | "Bold Italic" | "Bold" | "Italic" | "Regular";
 
 	/**
-	 * Determines whether the title associated with this state is underlined by default. **NB.** This can be overridden by the user in the Stream Deck application.
+	 * Determines whether the title associated with this state is underlined by default.
+	 *
+	 * NB: Can be overridden by the user in the Stream Deck application.
 	 */
 	FontUnderline?: boolean;
 
@@ -505,7 +528,7 @@ type ActionState = {
 	 * - Be in .PNG or .SVG format.
 	 * - Be provided in two sizes, 72x72 px and 144x144 px (@2x).
 	 *
-	 * **NB.** This can be overridden by the user in the Stream Deck application.
+	 * NB: Can be overridden by the user in the Stream Deck application.
 	 *
 	 * **Examples:**
 	 * - assets/counter-key
@@ -519,7 +542,7 @@ type ActionState = {
 	 * - Be in .PNG or .SVG format.
 	 * - Be provided in two sizes, 72x72 px and 144x144 px (@2x).
 	 *
-	 * **NB.** This can be overridden by the user in the Stream Deck application.
+	 * NB: Can be overridden by the user in the Stream Deck application.
 	 *
 	 * **Examples:**
 	 * - assets/counter-key
@@ -534,7 +557,9 @@ type ActionState = {
 	Name?: string;
 
 	/**
-	 * Determines whether the title should be shown. **NB.** This can be overridden by the user in the Stream Deck application.
+	 * Determines whether the title should be shown.
+	 *
+	 * NB: Can be overridden by the user in the Stream Deck application.
 	 */
 	ShowTitle?: boolean;
 
@@ -544,13 +569,16 @@ type ActionState = {
 	Title?: string;
 
 	/**
-	 * Default title alignment to be used when rendering the title of this state. **NB.** This can be overridden by the user in the Stream Deck application.
+	 * Default title alignment to be used when rendering the title of this state.
+	 *
+	 * NB: Can be overridden by the user in the Stream Deck application.
 	 */
 	TitleAlignment?: "bottom" | "middle" | "top";
 
 	/**
-	 * Default title color to be used when rendering the title of this state, represented a hexadecimal value. **NB.** This can be overridden by the user in the Stream Deck
-	 * application.
+	 * Default title color to be used when rendering the title of this state, represented a hexadecimal value.
+	 *
+	 * NB: Can be overridden by the user in the Stream Deck application.
 	 *
 	 * **Examples:**
 	 * - #5bcefa

--- a/src/profiles.ts
+++ b/src/profiles.ts
@@ -13,10 +13,11 @@ export class ProfileClient {
 
 	/**
 	 * Requests the Stream Deck switches the current profile of the specified {@link deviceId} to the {@link profile}; when no {@link profile} is provided the previously active profile
-	 * is activated. **NB**, plugins can only switch to profiles included as part
-	 * of the plugin and defined within the manifest, and cannot switch to custom profiles created by users.
+	 * is activated.
+	 *
+	 * NB: Plugins may only switch to profiles distributed with the plugin, as defined within the manifest, and cannot access user-defined profiles.
 	 * @param deviceId Unique identifier of the device where the profile should be set.
-	 * @param profile Optional name of the profile to switch to; when `undefined` the previous profile will be activated. **NB** name must be identical to the one provided in the manifest.
+	 * @param profile Optional name of the profile to switch to; when `undefined` the previous profile will be activated. Name must be identical to the one provided in the manifest.
 	 * @param page Optional page to show when switching to the {@link profile}, indexed from 0. When `undefined`, the page that was previously visible (when switching away from the
 	 * profile) will be made visible.
 	 * @returns `Promise` resolved when the request to switch the `profile` has been sent to Stream Deck.


### PR DESCRIPTION
- Fix default `text-overflow` for layout text elements.
- Update validation of paths that should not contain an extension.
- Improved documentation for numerical-enum values.
- Standardized "NB" comments.