### PR TITLE
fix: exporting

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -10,6 +10,7 @@ describe("Index", () => {
 		// Arrange, act, assert.
 		const index = (await require("../index")) as typeof import("../index");
 		expect(index.default).toBeInstanceOf(StreamDeck);
+		expect(index.default).toStrictEqual(index.streamDeck);
 		expect(StreamDeck).toHaveBeenCalledTimes(1);
 		expect(StreamDeck).toHaveBeenCalledWith();
 	});

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,4 +10,5 @@ export * from "./events";
 export { LogLevel } from "./logging";
 export { Manifest } from "./manifest";
 
-export default new StreamDeck();
+export const streamDeck = new StreamDeck();
+export default streamDeck;

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { StreamDeck } from "./stream-deck";
 export { Action } from "./actions/action";
 export { action } from "./actions/decorators";
 export { SingletonAction } from "./actions/singleton-action";
+export { PayloadObject } from "./connectivity/events";
 export * from "./connectivity/layouts";
 export { Target } from "./connectivity/target";
 export * from "./events";


### PR DESCRIPTION
- Export `PayloadObject` to enable extending `SingletonAction`.
- Export default as named const to improve intellisense.