### PR TITLE
fix: schema validation

### DIFF
--- a/schemas/manifest.json
+++ b/schemas/manifest.json
@@ -274,7 +274,7 @@
 							"UUID": {
 								"type": "string",
 								"description": "Unique identifier of the action, represented in reverse-DNS format. This value is supplied by Stream Deck when events are emitted that relate to the action enabling you to identify the source of the event.\n\n**Allowed characters:**\n- Lowercase alphanumeric characters (a-z, 0-9)\n- Hyphens (-)\n- Underscores (_)\n- Periods (.)\n\nNB: `UUID` must be unique, and should be prefixed with the plugin's UUID.\n\n\n**Examples:**\n- com.elgato.wavelink.toggle-mute\n- com.elgato.discord.join-voice\n- tv.twitch.go-live",
-								"pattern": "^([a-z0-9\\-_]*[a-z0-9][a-z0-9\\-_]*\\.){2,3}[a-z0-9\\-_]*[a-z0-9][a-z0-9\\-_]*$",
+								"pattern": "^([a-z0-9\\-_]+)(\\.[a-z0-9\\-_]+)+$",
 								"markdownDescription": "Unique identifier of the action, represented in reverse-DNS format. This value is supplied by Stream Deck when events are emitted that relate to the action enabling you to identify the source of the event.\n\n**Allowed characters:**\n- Lowercase alphanumeric characters (a-z, 0-9)\n- Hyphens (-)\n- Underscores (_)\n- Periods (.)\n\nNB: `UUID` must be unique, and should be prefixed with the plugin's UUID.\n\n\n**Examples:**\n- com.elgato.wavelink.toggle-mute\n- com.elgato.discord.join-voice\n- tv.twitch.go-live"
 							},
 							"UserTitleEnabled": {

--- a/schemas/manifest.json
+++ b/schemas/manifest.json
@@ -47,8 +47,16 @@
 									"Icon": {
 										"type": "string",
 										"description": "Path to the image, with the **file extension omitted**, that will be displayed in the Stream Deck application in the circular canvas that represents the dial of the action. The image must fulfill the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 72x72 px and 144x144 px (@2x).\n\nNB: Can be overridden by the user in the Stream Deck application.\n\n**Examples:**\n- assets/actions/mute/encoder-icon\n- imgs/join-voice-chat-encoder",
-										"pattern": "^[^.]+$",
-										"markdownDescription": "Path to the image, with the **file extension omitted**, that will be displayed in the Stream Deck application in the circular canvas that represents the dial of the action. The image must fulfill the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 72x72 px and 144x144 px (@2x).\n\nNB: Can be overridden by the user in the Stream Deck application.\n\n**Examples:**\n- assets/actions/mute/encoder-icon\n- imgs/join-voice-chat-encoder"
+										"filePath": {
+											"extensions": [
+												".gif",
+												".svg",
+												".png"
+											],
+											"includeExtension": false
+										},
+										"markdownDescription": "Path to the image, with the **file extension omitted**, that will be displayed in the Stream Deck application in the circular canvas that represents the dial of the action. The image must fulfill the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 72x72 px and 144x144 px (@2x).\n\nNB: Can be overridden by the user in the Stream Deck application.\n\n**Examples:**\n- assets/actions/mute/encoder-icon\n- imgs/join-voice-chat-encoder",
+										"pattern": "^(?![~\\.]*[\\\\\\/]+)(?!.*\\.(([Gg][Ii][Ff])|([Ss][Vv][Gg])|([Pp][Nn][Gg]))$).*$"
 									},
 									"StackColor": {
 										"type": "string",
@@ -87,8 +95,15 @@
 									"background": {
 										"type": "string",
 										"description": "Path to the image, with the **file extension omitted**, that will be displayed on the touchscreen behind the action's layout. The image must fulfill the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 200x100 px and 400x200 px (@2x).\n\nNB: Can be overridden by the user in the Stream Deck application.\n\n**Examples:**\n- assets/backgrounds/main\n- imgs/bright-blue-bg",
-										"pattern": "^[^.]+$",
-										"markdownDescription": "Path to the image, with the **file extension omitted**, that will be displayed on the touchscreen behind the action's layout. The image must fulfill the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 200x100 px and 400x200 px (@2x).\n\nNB: Can be overridden by the user in the Stream Deck application.\n\n**Examples:**\n- assets/backgrounds/main\n- imgs/bright-blue-bg"
+										"filePath": {
+											"extensions": [
+												".png",
+												".svg"
+											],
+											"includeExtension": false
+										},
+										"markdownDescription": "Path to the image, with the **file extension omitted**, that will be displayed on the touchscreen behind the action's layout. The image must fulfill the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 200x100 px and 400x200 px (@2x).\n\nNB: Can be overridden by the user in the Stream Deck application.\n\n**Examples:**\n- assets/backgrounds/main\n- imgs/bright-blue-bg",
+										"pattern": "^(?![~\\.]*[\\\\\\/]+)(?!.*\\.(([Pp][Nn][Gg])|([Ss][Vv][Gg]))$).*$"
 									},
 									"layout": {
 										"type": "string",
@@ -112,8 +127,16 @@
 							"Icon": {
 								"type": "string",
 								"description": "Path to the image, with the **file extension omitted**, that will be displayed next to the action in the Stream Deck application's action list. The image must adhere to the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 20x20 px and 40x40 px (@2x).\n- Be monochromatic, with foreground color of #EFEFEF and a transparent background.\n\n**Examples:**\n- assets/counter\n- imgs/actions/mute",
-								"pattern": "^[^.]+$",
-								"markdownDescription": "Path to the image, with the **file extension omitted**, that will be displayed next to the action in the Stream Deck application's action list. The image must adhere to the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 20x20 px and 40x40 px (@2x).\n- Be monochromatic, with foreground color of #EFEFEF and a transparent background.\n\n**Examples:**\n- assets/counter\n- imgs/actions/mute"
+								"filePath": {
+									"extensions": [
+										".gif",
+										".svg",
+										".png"
+									],
+									"includeExtension": false
+								},
+								"markdownDescription": "Path to the image, with the **file extension omitted**, that will be displayed next to the action in the Stream Deck application's action list. The image must adhere to the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 20x20 px and 40x40 px (@2x).\n- Be monochromatic, with foreground color of #EFEFEF and a transparent background.\n\n**Examples:**\n- assets/counter\n- imgs/actions/mute",
+								"pattern": "^(?![~\\.]*[\\\\\\/]+)(?!.*\\.(([Gg][Ii][Ff])|([Ss][Vv][Gg])|([Pp][Nn][Gg]))$).*$"
 							},
 							"Name": {
 								"type": "string",
@@ -123,8 +146,15 @@
 							"PropertyInspectorPath": {
 								"type": "string",
 								"description": "Optional path to the HTML file that represents the property inspector for this action; this is displayed to the user in the Stream Deck application when they add the action, allowing them to configure the action's settings. When `undefined`, the manifest's top-level `PropertyInspectorPath` is used, otherwise none.\n\nNB: Path should be relative to the root of the plugin's folder, with no leading slash.\n\n**Examples:**\n- mute.html\n- actions/join-voice-chat/settings.html",
-								"pattern": "^(?!\\/).+\\.[Hh][Tt][Mm][Ll]?$",
-								"markdownDescription": "Optional path to the HTML file that represents the property inspector for this action; this is displayed to the user in the Stream Deck application when they add the action, allowing them to configure the action's settings. When `undefined`, the manifest's top-level `PropertyInspectorPath` is used, otherwise none.\n\nNB: Path should be relative to the root of the plugin's folder, with no leading slash.\n\n**Examples:**\n- mute.html\n- actions/join-voice-chat/settings.html"
+								"filePath": {
+									"extensions": [
+										".htm",
+										".html"
+									],
+									"includeExtension": true
+								},
+								"markdownDescription": "Optional path to the HTML file that represents the property inspector for this action; this is displayed to the user in the Stream Deck application when they add the action, allowing them to configure the action's settings. When `undefined`, the manifest's top-level `PropertyInspectorPath` is used, otherwise none.\n\nNB: Path should be relative to the root of the plugin's folder, with no leading slash.\n\n**Examples:**\n- mute.html\n- actions/join-voice-chat/settings.html",
+								"pattern": "^(?![~\\.]*[\\\\\\/]+).*\\.(([Hh][Tt][Mm])|([Hh][Tt][Mm][Ll]))$"
 							},
 							"States": {
 								"type": "array",
@@ -161,14 +191,30 @@
 										"Image": {
 											"type": "string",
 											"description": "Path to the image, with the **file extension omitted**, that will be displayed on the Stream Deck when this action's state is active. The image must adhere to the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 72x72 px and 144x144 px (@2x).\n\nNB: Can be overridden by the user in the Stream Deck application.\n\n**Examples:**\n- assets/counter-key\n- assets/icons/mute",
-											"pattern": "^[^.]+$",
-											"markdownDescription": "Path to the image, with the **file extension omitted**, that will be displayed on the Stream Deck when this action's state is active. The image must adhere to the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 72x72 px and 144x144 px (@2x).\n\nNB: Can be overridden by the user in the Stream Deck application.\n\n**Examples:**\n- assets/counter-key\n- assets/icons/mute"
+											"filePath": {
+												"extensions": [
+													".gif",
+													".svg",
+													".png"
+												],
+												"includeExtension": false
+											},
+											"markdownDescription": "Path to the image, with the **file extension omitted**, that will be displayed on the Stream Deck when this action's state is active. The image must adhere to the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 72x72 px and 144x144 px (@2x).\n\nNB: Can be overridden by the user in the Stream Deck application.\n\n**Examples:**\n- assets/counter-key\n- assets/icons/mute",
+											"pattern": "^(?![~\\.]*[\\\\\\/]+)(?!.*\\.(([Gg][Ii][Ff])|([Ss][Vv][Gg])|([Pp][Nn][Gg]))$).*$"
 										},
 										"MultiActionImage": {
 											"type": "string",
 											"description": "Path to the image, with the **file extension omitted**, that will be displayed when the action is being viewed as part of a multi-action. The image must adhere to the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 72x72 px and 144x144 px (@2x).\n\nNB: Can be overridden by the user in the Stream Deck application.\n\n**Examples:**\n- assets/counter-key\n- assets/icons/mute",
-											"pattern": "^[^.]+$",
-											"markdownDescription": "Path to the image, with the **file extension omitted**, that will be displayed when the action is being viewed as part of a multi-action. The image must adhere to the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 72x72 px and 144x144 px (@2x).\n\nNB: Can be overridden by the user in the Stream Deck application.\n\n**Examples:**\n- assets/counter-key\n- assets/icons/mute"
+											"filePath": {
+												"extensions": [
+													".gif",
+													".svg",
+													".png"
+												],
+												"includeExtension": false
+											},
+											"markdownDescription": "Path to the image, with the **file extension omitted**, that will be displayed when the action is being viewed as part of a multi-action. The image must adhere to the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 72x72 px and 144x144 px (@2x).\n\nNB: Can be overridden by the user in the Stream Deck application.\n\n**Examples:**\n- assets/counter-key\n- assets/icons/mute",
+											"pattern": "^(?![~\\.]*[\\\\\\/]+)(?!.*\\.(([Gg][Ii][Ff])|([Ss][Vv][Gg])|([Pp][Nn][Gg]))$).*$"
 										},
 										"Name": {
 											"type": "string",
@@ -289,23 +335,36 @@
 				"CategoryIcon": {
 					"type": "string",
 					"description": "Path to the image, with the **file extension omitted**, that will be displayed next to the action list group within the Stream Deck application. The icon should accurately represent the plugin, and enable users to quickly identify the plugin. The icon must adhere to the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 28x28 px and 56x56 px (@2x).\n- Be monochromatic, with foreground color of #DFDFDF and a transparent background.\n\n**Examples**:\n- assets/category-icon\n- imgs/category",
-					"pattern": "^[^.]+$",
-					"markdownDescription": "Path to the image, with the **file extension omitted**, that will be displayed next to the action list group within the Stream Deck application. The icon should accurately represent the plugin, and enable users to quickly identify the plugin. The icon must adhere to the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 28x28 px and 56x56 px (@2x).\n- Be monochromatic, with foreground color of #DFDFDF and a transparent background.\n\n**Examples**:\n- assets/category-icon\n- imgs/category"
+					"filePath": {
+						"extensions": [
+							".svg",
+							".png"
+						],
+						"includeExtension": false
+					},
+					"markdownDescription": "Path to the image, with the **file extension omitted**, that will be displayed next to the action list group within the Stream Deck application. The icon should accurately represent the plugin, and enable users to quickly identify the plugin. The icon must adhere to the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 28x28 px and 56x56 px (@2x).\n- Be monochromatic, with foreground color of #DFDFDF and a transparent background.\n\n**Examples**:\n- assets/category-icon\n- imgs/category",
+					"pattern": "^(?![~\\.]*[\\\\\\/]+)(?!.*\\.(([Ss][Vv][Gg])|([Pp][Nn][Gg]))$).*$"
 				},
 				"CodePath": {
 					"type": "string",
 					"description": "Path to the plugin's main entry point; this is executed when the Stream Deck application starts the plugin.\n\n**Examples**:\n- index.js\n- Counter\n- Counter.exe",
-					"markdownDescription": "Path to the plugin's main entry point; this is executed when the Stream Deck application starts the plugin.\n\n**Examples**:\n- index.js\n- Counter\n- Counter.exe"
+					"filePath": true,
+					"markdownDescription": "Path to the plugin's main entry point; this is executed when the Stream Deck application starts the plugin.\n\n**Examples**:\n- index.js\n- Counter\n- Counter.exe",
+					"pattern": "^(?![~\\.]*[\\\\\\/]+).*$"
 				},
 				"CodePathMac": {
 					"type": "string",
 					"description": "Path to the plugin's entry point specific to macOS; this is executed when the Stream Deck application starts the plugin on macOS.\n\n**Examples:**\n- index.js\n- Counter",
-					"markdownDescription": "Path to the plugin's entry point specific to macOS; this is executed when the Stream Deck application starts the plugin on macOS.\n\n**Examples:**\n- index.js\n- Counter"
+					"filePath": true,
+					"markdownDescription": "Path to the plugin's entry point specific to macOS; this is executed when the Stream Deck application starts the plugin on macOS.\n\n**Examples:**\n- index.js\n- Counter",
+					"pattern": "^(?![~\\.]*[\\\\\\/]+).*$"
 				},
 				"CodePathWin": {
 					"type": "string",
 					"description": "Path to the plugin's entry point specific to Windows; this is executed when the Stream Deck application starts the plugin on Windows.\n\n**Examples:**\n- index.js\n- Counter.exe",
-					"markdownDescription": "Path to the plugin's entry point specific to Windows; this is executed when the Stream Deck application starts the plugin on Windows.\n\n**Examples:**\n- index.js\n- Counter.exe"
+					"filePath": true,
+					"markdownDescription": "Path to the plugin's entry point specific to Windows; this is executed when the Stream Deck application starts the plugin on Windows.\n\n**Examples:**\n- index.js\n- Counter.exe",
+					"pattern": "^(?![~\\.]*[\\\\\\/]+).*$"
 				},
 				"DefaultWindowSize": {
 					"type": "array",
@@ -331,8 +390,16 @@
 				"Icon": {
 					"type": "string",
 					"description": "Path to the image, with the **file extension omitted**, that will be displayed on the Marketplace. The icon should accurately represent the plugin, stand out, and enable users to quickly identify the plugin. The icon must adhere to the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 288x288 px and 512x512 px (@2x).\n\n**Examples**: assets/plugin-icon imgs/plugin",
-					"pattern": "^[^.]+$",
-					"markdownDescription": "Path to the image, with the **file extension omitted**, that will be displayed on the Marketplace. The icon should accurately represent the plugin, stand out, and enable users to quickly identify the plugin. The icon must adhere to the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 288x288 px and 512x512 px (@2x).\n\n**Examples**: assets/plugin-icon imgs/plugin"
+					"filePath": {
+						"extensions": [
+							".gif",
+							".svg",
+							".png"
+						],
+						"includeExtension": false
+					},
+					"markdownDescription": "Path to the image, with the **file extension omitted**, that will be displayed on the Marketplace. The icon should accurately represent the plugin, stand out, and enable users to quickly identify the plugin. The icon must adhere to the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 288x288 px and 512x512 px (@2x).\n\n**Examples**: assets/plugin-icon imgs/plugin",
+					"pattern": "^(?![~\\.]*[\\\\\\/]+)(?!.*\\.(([Gg][Ii][Ff])|([Ss][Vv][Gg])|([Pp][Nn][Gg]))$).*$"
 				},
 				"Name": {
 					"type": "string",
@@ -431,7 +498,14 @@
 							"Name": {
 								"type": "string",
 								"description": "Path to the `.streamDeckProfile`, with the **file extension omitted**, that contains the profiles layout and action settings.\n\n**Examples:**\n- assets/main-profile\n- profiles/super-cool-profile",
-								"markdownDescription": "Path to the `.streamDeckProfile`, with the **file extension omitted**, that contains the profiles layout and action settings.\n\n**Examples:**\n- assets/main-profile\n- profiles/super-cool-profile"
+								"filePath": {
+									"extensions": [
+										".streamDeckProfile"
+									],
+									"includeExtension": false
+								},
+								"markdownDescription": "Path to the `.streamDeckProfile`, with the **file extension omitted**, that contains the profiles layout and action settings.\n\n**Examples:**\n- assets/main-profile\n- profiles/super-cool-profile",
+								"pattern": "^(?![~\\.]*[\\\\\\/]+)(?!.*\\.(([Ss][Tt][Rr][Ee][Aa][Mm][Dd][Ee][Cc][Kk][Pp][Rr][Oo][Ff][Ii][Ll][Ee]))$).*$"
 							},
 							"Readonly": {
 								"type": "boolean",
@@ -451,8 +525,15 @@
 				"PropertyInspectorPath": {
 					"type": "string",
 					"description": "Optional path to the HTML file that represents the property inspector for all actions; this is displayed to the user in the Stream Deck application when they add an action, allowing them to configure the action's settings.\n\nNB: Path should be relative to the root of the plugin's folder, with no leading slash.\n\n **Examples:**\n- mute.html\n- actions/join-voice-chat/settings.html\n\n**Also see:**\n- `streamDeck.ui.onSendToPlugin(...)`",
-					"pattern": "^(?!\\/).+\\.[Hh][Tt][Mm][Ll]?$",
-					"markdownDescription": "Optional path to the HTML file that represents the property inspector for all actions; this is displayed to the user in the Stream Deck application when they add an action, allowing them to configure the action's settings.\n\nNB: Path should be relative to the root of the plugin's folder, with no leading slash.\n\n **Examples:**\n- mute.html\n- actions/join-voice-chat/settings.html\n\n**Also see:**\n- `streamDeck.ui.onSendToPlugin(...)`"
+					"filePath": {
+						"extensions": [
+							".htm",
+							".html"
+						],
+						"includeExtension": true
+					},
+					"markdownDescription": "Optional path to the HTML file that represents the property inspector for all actions; this is displayed to the user in the Stream Deck application when they add an action, allowing them to configure the action's settings.\n\nNB: Path should be relative to the root of the plugin's folder, with no leading slash.\n\n **Examples:**\n- mute.html\n- actions/join-voice-chat/settings.html\n\n**Also see:**\n- `streamDeck.ui.onSendToPlugin(...)`",
+					"pattern": "^(?![~\\.]*[\\\\\\/]+).*\\.(([Hh][Tt][Mm])|([Hh][Tt][Mm][Ll]))$"
 				},
 				"SDKVersion": {
 					"type": "number",

--- a/schemas/manifest.json
+++ b/schemas/manifest.json
@@ -115,9 +115,10 @@
 											"$A1",
 											"$B1",
 											"$B2",
-											"$C1"
+											"$C1",
+											"custom.json"
 										],
-										"pattern": "(^(\\$[AB][12])|(\\$[XC]1))$|(^(?!\\/).+\\.[Jj][Ss][Oo][Nn]$)",
+										"pattern": "^((?![\\.]*[\\\\\\/]+).*\\.([Jj][Ss][Oo][Nn]))|(\\$(X1|A0|A1|B1|B2|C1))$",
 										"markdownDescription": "Name of a pre-defined layout, or the path to a JSON file that details a custom layout and its components, to be rendered on the action's touchscreen canvas.\n\n**Pre-defined Layouts:**\n- `$X1`, layout with the title at the top and the icon beneath it in the center.\n- `$A0`, layout with the title at the top and a full-width image canvas beneath it in the center.\n- `$A1`, layout with the title at the top, the icon on the left, and text value on the right.\n- `$B1`, layout with the title at the top, the icon on the left, and a text value on the right with a progress bar beneath it.\n- `$B2`, layout with the title at the top, the icon on the left, and a text value on the right with a gradient progress bar beneath it.\n- `$C1`, layout with the title at the top, and two rows that display an icon on the left and progress bar on the right (i.e. a double progress bar layout).\n\n**Examples:**\n- $A1\n- layouts/my-custom-layout.json"
 									}
 								},

--- a/schemas/manifest.json
+++ b/schemas/manifest.json
@@ -568,11 +568,12 @@
 				},
 				"Version": {
 					"type": "string",
-					"description": "Version of the plugin, represented as a  {@link  https://semver.org semantic version }  (excluding pre-release values).\n\n**Examples:**\n- 1.0.3 ✅\n- 0.0.99 ✅\n- 2.1.9-beta1 ❌",
+					"description": "Version of the plugin, represented as a semantic version, excluding pre-release values (https://semver.org). The version can also include an optional build number.\n\n**Examples:**\n- 1.0.3 ✅\n- 0.0.99.123 ✅\n- 2.1.9-beta1 ❌",
 					"examples": [
 						"1.0.0"
 					],
-					"markdownDescription": "Version of the plugin, represented as a  {@link  https://semver.org semantic version }  (excluding pre-release values).\n\n**Examples:**\n- 1.0.3 ✅\n- 0.0.99 ✅\n- 2.1.9-beta1 ❌"
+					"pattern": "^\\d+(\\.\\d+){2,3}$",
+					"markdownDescription": "Version of the plugin, represented as a semantic version, excluding pre-release values (https://semver.org). The version can also include an optional build number.\n\n**Examples:**\n- 1.0.3 ✅\n- 0.0.99.123 ✅\n- 2.1.9-beta1 ❌"
 				}
 			},
 			"required": [

--- a/schemas/manifest.json
+++ b/schemas/manifest.json
@@ -23,6 +23,7 @@
 								"minItems": 1,
 								"maxItems": 2,
 								"description": "Defines the controller type the action is applicable to. **Keypad** refers to a standard action on a Stream Deck device, e.g. 1 of the 15 buttons on the Stream Deck MK.2, or a pedal on the Stream Deck Pedal, etc., whereas an **Encoder** refers to a dial / touchscreen on the Stream Deck+.",
+								"uniqueItems": true,
 								"markdownDescription": "Defines the controller type the action is applicable to. **Keypad** refers to a standard action on a Stream Deck device, e.g. 1 of the 15 buttons on the Stream Deck MK.2, or a pedal on the Stream Deck Pedal, etc., whereas an **Encoder** refers to a dial / touchscreen on the Stream Deck+."
 							},
 							"DisableAutomaticStates": {

--- a/schemas/manifest.json
+++ b/schemas/manifest.json
@@ -57,12 +57,14 @@
 											"includeExtension": false
 										},
 										"markdownDescription": "Path to the image, with the **file extension omitted**, that will be displayed in the Stream Deck application in the circular canvas that represents the dial of the action. The image must fulfill the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 72x72 px and 144x144 px (@2x).\n\nNB: Can be overridden by the user in the Stream Deck application.\n\n**Examples:**\n- assets/actions/mute/encoder-icon\n- imgs/join-voice-chat-encoder",
-										"pattern": "^(?![~\\.]*[\\\\\\/]+)(?!.*\\.(([Gg][Ii][Ff])|([Ss][Vv][Gg])|([Pp][Nn][Gg]))$).*$"
+										"pattern": "^(?![~\\.]*[\\\\\\/]+)(?!.*\\.(([Gg][Ii][Ff])|([Ss][Vv][Gg])|([Pp][Nn][Gg]))$).*$",
+										"errorMessage": "String must be a .gif, .svg, or .png file located within the plugin's directory, with the file extension omitted"
 									},
 									"StackColor": {
 										"type": "string",
 										"description": "Background color to display in the Stream Deck application when the action is part of a dial stack, and is the current action. Represented as a hexadecimal value.\n\n**Examples:**\n- #d60270\n- #1f1f1\n- #0038a8",
 										"pattern": "^#(?:[0-9a-fA-F]{3}){1,2}$",
+										"errorMessage": "String must be hexadecimal color.",
 										"markdownDescription": "Background color to display in the Stream Deck application when the action is part of a dial stack, and is the current action. Represented as a hexadecimal value.\n\n**Examples:**\n- #d60270\n- #1f1f1\n- #0038a8"
 									},
 									"TriggerDescription": {
@@ -104,7 +106,8 @@
 											"includeExtension": false
 										},
 										"markdownDescription": "Path to the image, with the **file extension omitted**, that will be displayed on the touchscreen behind the action's layout. The image must fulfill the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 200x100 px and 400x200 px (@2x).\n\nNB: Can be overridden by the user in the Stream Deck application.\n\n**Examples:**\n- assets/backgrounds/main\n- imgs/bright-blue-bg",
-										"pattern": "^(?![~\\.]*[\\\\\\/]+)(?!.*\\.(([Pp][Nn][Gg])|([Ss][Vv][Gg]))$).*$"
+										"pattern": "^(?![~\\.]*[\\\\\\/]+)(?!.*\\.(([Pp][Nn][Gg])|([Ss][Vv][Gg]))$).*$",
+										"errorMessage": "String must be a .png, or .svg file located within the plugin's directory, with the file extension omitted"
 									},
 									"layout": {
 										"type": "string",
@@ -119,6 +122,7 @@
 											"custom.json"
 										],
 										"pattern": "^((?![\\.]*[\\\\\\/]+).*\\.([Jj][Ss][Oo][Nn]))|(\\$(X1|A0|A1|B1|B2|C1))$",
+										"errorMessage": "String must be a pre-defined layout, or a .json file located within the plugin's directory",
 										"markdownDescription": "Name of a pre-defined layout, or the path to a JSON file that details a custom layout and its components, to be rendered on the action's touchscreen canvas.\n\n**Pre-defined Layouts:**\n- `$X1`, layout with the title at the top and the icon beneath it in the center.\n- `$A0`, layout with the title at the top and a full-width image canvas beneath it in the center.\n- `$A1`, layout with the title at the top, the icon on the left, and text value on the right.\n- `$B1`, layout with the title at the top, the icon on the left, and a text value on the right with a progress bar beneath it.\n- `$B2`, layout with the title at the top, the icon on the left, and a text value on the right with a gradient progress bar beneath it.\n- `$C1`, layout with the title at the top, and two rows that display an icon on the left and progress bar on the right (i.e. a double progress bar layout).\n\n**Examples:**\n- $A1\n- layouts/my-custom-layout.json"
 									}
 								},
@@ -138,7 +142,8 @@
 									"includeExtension": false
 								},
 								"markdownDescription": "Path to the image, with the **file extension omitted**, that will be displayed next to the action in the Stream Deck application's action list. The image must adhere to the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 20x20 px and 40x40 px (@2x).\n- Be monochromatic, with foreground color of #EFEFEF and a transparent background.\n\n**Examples:**\n- assets/counter\n- imgs/actions/mute",
-								"pattern": "^(?![~\\.]*[\\\\\\/]+)(?!.*\\.(([Gg][Ii][Ff])|([Ss][Vv][Gg])|([Pp][Nn][Gg]))$).*$"
+								"pattern": "^(?![~\\.]*[\\\\\\/]+)(?!.*\\.(([Gg][Ii][Ff])|([Ss][Vv][Gg])|([Pp][Nn][Gg]))$).*$",
+								"errorMessage": "String must be a .gif, .svg, or .png file located within the plugin's directory, with the file extension omitted"
 							},
 							"Name": {
 								"type": "string",
@@ -156,7 +161,8 @@
 									"includeExtension": true
 								},
 								"markdownDescription": "Optional path to the HTML file that represents the property inspector for this action; this is displayed to the user in the Stream Deck application when they add the action, allowing them to configure the action's settings. When `undefined`, the manifest's top-level `PropertyInspectorPath` is used, otherwise none.\n\nNB: Path should be relative to the root of the plugin's folder, with no leading slash.\n\n**Examples:**\n- mute.html\n- actions/join-voice-chat/settings.html",
-								"pattern": "^(?![~\\.]*[\\\\\\/]+).*\\.(([Hh][Tt][Mm])|([Hh][Tt][Mm][Ll]))$"
+								"pattern": "^(?![~\\.]*[\\\\\\/]+).*\\.(([Hh][Tt][Mm])|([Hh][Tt][Mm][Ll]))$",
+								"errorMessage": "String must be a .htm, or .html file located within the plugin's directory"
 							},
 							"States": {
 								"type": "array",
@@ -202,7 +208,8 @@
 												"includeExtension": false
 											},
 											"markdownDescription": "Path to the image, with the **file extension omitted**, that will be displayed on the Stream Deck when this action's state is active. The image must adhere to the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 72x72 px and 144x144 px (@2x).\n\nNB: Can be overridden by the user in the Stream Deck application.\n\n**Examples:**\n- assets/counter-key\n- assets/icons/mute",
-											"pattern": "^(?![~\\.]*[\\\\\\/]+)(?!.*\\.(([Gg][Ii][Ff])|([Ss][Vv][Gg])|([Pp][Nn][Gg]))$).*$"
+											"pattern": "^(?![~\\.]*[\\\\\\/]+)(?!.*\\.(([Gg][Ii][Ff])|([Ss][Vv][Gg])|([Pp][Nn][Gg]))$).*$",
+											"errorMessage": "String must be a .gif, .svg, or .png file located within the plugin's directory, with the file extension omitted"
 										},
 										"MultiActionImage": {
 											"type": "string",
@@ -216,7 +223,8 @@
 												"includeExtension": false
 											},
 											"markdownDescription": "Path to the image, with the **file extension omitted**, that will be displayed when the action is being viewed as part of a multi-action. The image must adhere to the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 72x72 px and 144x144 px (@2x).\n\nNB: Can be overridden by the user in the Stream Deck application.\n\n**Examples:**\n- assets/counter-key\n- assets/icons/mute",
-											"pattern": "^(?![~\\.]*[\\\\\\/]+)(?!.*\\.(([Gg][Ii][Ff])|([Ss][Vv][Gg])|([Pp][Nn][Gg]))$).*$"
+											"pattern": "^(?![~\\.]*[\\\\\\/]+)(?!.*\\.(([Gg][Ii][Ff])|([Ss][Vv][Gg])|([Pp][Nn][Gg]))$).*$",
+											"errorMessage": "String must be a .gif, .svg, or .png file located within the plugin's directory, with the file extension omitted"
 										},
 										"Name": {
 											"type": "string",
@@ -247,6 +255,7 @@
 											"type": "string",
 											"description": "Default title color to be used when rendering the title of this state, represented a hexadecimal value.\n\nNB: Can be overridden by the user in the Stream Deck application.\n\n**Examples:**\n- #5bcefa\n- #f5a9b8\n- #FFFFFF",
 											"pattern": "^#(?:[0-9a-fA-F]{3}){1,2}$",
+											"errorMessage": "String must be hexadecimal color.",
 											"markdownDescription": "Default title color to be used when rendering the title of this state, represented a hexadecimal value.\n\nNB: Can be overridden by the user in the Stream Deck application.\n\n**Examples:**\n- #5bcefa\n- #f5a9b8\n- #FFFFFF"
 										}
 									},
@@ -276,6 +285,7 @@
 								"type": "string",
 								"description": "Unique identifier of the action, represented in reverse-DNS format. This value is supplied by Stream Deck when events are emitted that relate to the action enabling you to identify the source of the event.\n\n**Allowed characters:**\n- Lowercase alphanumeric characters (a-z, 0-9)\n- Hyphens (-)\n- Underscores (_)\n- Periods (.)\n\nNB: `UUID` must be unique, and should be prefixed with the plugin's UUID.\n\n\n**Examples:**\n- com.elgato.wavelink.toggle-mute\n- com.elgato.discord.join-voice\n- tv.twitch.go-live",
 								"pattern": "^([a-z0-9\\-_]+)(\\.[a-z0-9\\-_]+)+$",
+								"errorMessage": "String must use reverse DNS format, and must only contain lowercase alphanumeric characters (a-z, 0-9), hyphens (-), underscores (_), and periods (.)",
 								"markdownDescription": "Unique identifier of the action, represented in reverse-DNS format. This value is supplied by Stream Deck when events are emitted that relate to the action enabling you to identify the source of the event.\n\n**Allowed characters:**\n- Lowercase alphanumeric characters (a-z, 0-9)\n- Hyphens (-)\n- Underscores (_)\n- Periods (.)\n\nNB: `UUID` must be unique, and should be prefixed with the plugin's UUID.\n\n\n**Examples:**\n- com.elgato.wavelink.toggle-mute\n- com.elgato.discord.join-voice\n- tv.twitch.go-live"
 							},
 							"UserTitleEnabled": {
@@ -345,28 +355,32 @@
 						"includeExtension": false
 					},
 					"markdownDescription": "Path to the image, with the **file extension omitted**, that will be displayed next to the action list group within the Stream Deck application. The icon should accurately represent the plugin, and enable users to quickly identify the plugin. The icon must adhere to the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 28x28 px and 56x56 px (@2x).\n- Be monochromatic, with foreground color of #DFDFDF and a transparent background.\n\n**Examples**:\n- assets/category-icon\n- imgs/category",
-					"pattern": "^(?![~\\.]*[\\\\\\/]+)(?!.*\\.(([Ss][Vv][Gg])|([Pp][Nn][Gg]))$).*$"
+					"pattern": "^(?![~\\.]*[\\\\\\/]+)(?!.*\\.(([Ss][Vv][Gg])|([Pp][Nn][Gg]))$).*$",
+					"errorMessage": "String must be a .svg, or .png file located within the plugin's directory, with the file extension omitted"
 				},
 				"CodePath": {
 					"type": "string",
 					"description": "Path to the plugin's main entry point; this is executed when the Stream Deck application starts the plugin.\n\n**Examples**:\n- index.js\n- Counter\n- Counter.exe",
 					"filePath": true,
 					"markdownDescription": "Path to the plugin's main entry point; this is executed when the Stream Deck application starts the plugin.\n\n**Examples**:\n- index.js\n- Counter\n- Counter.exe",
-					"pattern": "^(?![~\\.]*[\\\\\\/]+).*$"
+					"pattern": "^(?![~\\.]*[\\\\\\/]+).*$",
+					"errorMessage": "String must be a file located within the plugins's directory"
 				},
 				"CodePathMac": {
 					"type": "string",
 					"description": "Path to the plugin's entry point specific to macOS; this is executed when the Stream Deck application starts the plugin on macOS.\n\n**Examples:**\n- index.js\n- Counter",
 					"filePath": true,
 					"markdownDescription": "Path to the plugin's entry point specific to macOS; this is executed when the Stream Deck application starts the plugin on macOS.\n\n**Examples:**\n- index.js\n- Counter",
-					"pattern": "^(?![~\\.]*[\\\\\\/]+).*$"
+					"pattern": "^(?![~\\.]*[\\\\\\/]+).*$",
+					"errorMessage": "String must be a file located within the plugins's directory"
 				},
 				"CodePathWin": {
 					"type": "string",
 					"description": "Path to the plugin's entry point specific to Windows; this is executed when the Stream Deck application starts the plugin on Windows.\n\n**Examples:**\n- index.js\n- Counter.exe",
 					"filePath": true,
 					"markdownDescription": "Path to the plugin's entry point specific to Windows; this is executed when the Stream Deck application starts the plugin on Windows.\n\n**Examples:**\n- index.js\n- Counter.exe",
-					"pattern": "^(?![~\\.]*[\\\\\\/]+).*$"
+					"pattern": "^(?![~\\.]*[\\\\\\/]+).*$",
+					"errorMessage": "String must be a file located within the plugins's directory"
 				},
 				"DefaultWindowSize": {
 					"type": "array",
@@ -401,7 +415,8 @@
 						"includeExtension": false
 					},
 					"markdownDescription": "Path to the image, with the **file extension omitted**, that will be displayed on the Marketplace. The icon should accurately represent the plugin, stand out, and enable users to quickly identify the plugin. The icon must adhere to the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 288x288 px and 512x512 px (@2x).\n\n**Examples**: assets/plugin-icon imgs/plugin",
-					"pattern": "^(?![~\\.]*[\\\\\\/]+)(?!.*\\.(([Gg][Ii][Ff])|([Ss][Vv][Gg])|([Pp][Nn][Gg]))$).*$"
+					"pattern": "^(?![~\\.]*[\\\\\\/]+)(?!.*\\.(([Gg][Ii][Ff])|([Ss][Vv][Gg])|([Pp][Nn][Gg]))$).*$",
+					"errorMessage": "String must be a .gif, .svg, or .png file located within the plugin's directory, with the file extension omitted"
 				},
 				"Name": {
 					"type": "string",
@@ -507,7 +522,8 @@
 									"includeExtension": false
 								},
 								"markdownDescription": "Path to the `.streamDeckProfile`, with the **file extension omitted**, that contains the profiles layout and action settings.\n\n**Examples:**\n- assets/main-profile\n- profiles/super-cool-profile",
-								"pattern": "^(?![~\\.]*[\\\\\\/]+)(?!.*\\.(([Ss][Tt][Rr][Ee][Aa][Mm][Dd][Ee][Cc][Kk][Pp][Rr][Oo][Ff][Ii][Ll][Ee]))$).*$"
+								"pattern": "^(?![~\\.]*[\\\\\\/]+)(?!.*\\.(([Ss][Tt][Rr][Ee][Aa][Mm][Dd][Ee][Cc][Kk][Pp][Rr][Oo][Ff][Ii][Ll][Ee]))$).*$",
+								"errorMessage": "String must be a .streamDeckProfile file located within the plugin's directory, with the file extension omitted"
 							},
 							"Readonly": {
 								"type": "boolean",
@@ -535,7 +551,8 @@
 						"includeExtension": true
 					},
 					"markdownDescription": "Optional path to the HTML file that represents the property inspector for all actions; this is displayed to the user in the Stream Deck application when they add an action, allowing them to configure the action's settings.\n\nNB: Path should be relative to the root of the plugin's folder, with no leading slash.\n\n **Examples:**\n- mute.html\n- actions/join-voice-chat/settings.html\n\n**Also see:**\n- `streamDeck.ui.onSendToPlugin(...)`",
-					"pattern": "^(?![~\\.]*[\\\\\\/]+).*\\.(([Hh][Tt][Mm])|([Hh][Tt][Mm][Ll]))$"
+					"pattern": "^(?![~\\.]*[\\\\\\/]+).*\\.(([Hh][Tt][Mm])|([Hh][Tt][Mm][Ll]))$",
+					"errorMessage": "String must be a .htm, or .html file located within the plugin's directory"
 				},
 				"SDKVersion": {
 					"type": "number",
@@ -575,6 +592,7 @@
 						"1.0.0"
 					],
 					"pattern": "^\\d+(\\.\\d+){2,3}$",
+					"errorMessage": "String must be a semantic version (pre-releases are not permitted)",
 					"markdownDescription": "Version of the plugin, represented as a semantic version, excluding pre-release values (https://semver.org). The version can also include an optional build number.\n\n**Examples:**\n- 1.0.3 ✅\n- 0.0.99.123 ✅\n- 2.1.9-beta1 ❌"
 				}
 			},

--- a/scripts/generate-schemas.ts
+++ b/scripts/generate-schemas.ts
@@ -1,9 +1,11 @@
+/* eslint-disable no-useless-escape */
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { Schema, createGenerator } from "ts-json-schema-generator";
 
 // Create a generator so we're able to produce multiple schemas.
 const generator = createGenerator({
+	extraTags: ["filePath"],
 	path: join(__dirname, "../src/index.ts"),
 	skipTypeCheck: true,
 	tsconfig: join(__dirname, "../tsconfig.json")
@@ -24,7 +26,7 @@ generateAndWriteSchema("Layout");
  */
 function generateAndWriteSchema(type: string): void {
 	const schema = generator.createSchema(type);
-	addMarkdownDescription(schema);
+	applyCustomKeywords(schema);
 
 	const outputPath = join(outputDir, `${type.toLowerCase()}.json`);
 	const contents = JSON.stringify(schema, null, "\t");
@@ -34,19 +36,84 @@ function generateAndWriteSchema(type: string): void {
 }
 
 /**
- * Traverses the specified `schema` and appends the `markdownDescription` property for all definitions within the schema that have a `description`.
- * @param schema Schema definition whose properties should be traversed, and `markdownDescription` applied.
+ * Applies the custom keywords, aggregating the schema to form a valid structure.
+ * @param schema Schema to apply the custom keywords to.
  */
-function addMarkdownDescription(schema: ExtendedSchema): void {
+function applyCustomKeywords(schema: ExtendedSchema): void {
+	visitNode(schema, (node, keyword, value) => {
+		switch (keyword) {
+			case "description":
+				node.markdownDescription = value?.toString();
+				break;
+
+			case "filePath":
+				node.pattern = generatePathPattern(value as FilePathOptions);
+				break;
+		}
+	});
+}
+
+/**
+ * Generates the regular expression pattern of a property based file path's {@link options}.
+ * - {@link https://regexr.com/7qpi6 File path, with unknown extension}
+ * - {@link https://regexr.com/7qpj7 File path, with extension}
+ * - {@link https://regexr.com/7qp5k File path, without extension}
+ * @param options Options used to determine how the pattern should be generated.
+ * @returns Regular expression pattern.
+ */
+function generatePathPattern(options: FilePathOptions): string {
+	let pattern = "^(?![~\\.]*[\\\\\\/]+)"; // ensure the value doesn't start with a slash, or period followed by a slash.
+
+	// When the file path's extension is unknown, we simply ensure the start of the string.
+	if (typeof options === "boolean") {
+		if (!options) {
+			throw new TypeError(`"false" is not a valid value for "filePath", expected: "true"`);
+		}
+
+		return (pattern += ".*$");
+	}
+
+	// Validate the options are present.
+	if (typeof options !== "object" || !("extensions" in options) || !("includeExtension" in options)) {
+		throw new TypeError(`${JSON.stringify(options)} is not a complete set of "filePath" options, expected: { "extensions": string[], "includeExtension": boolean }`);
+	}
+
+	// Otherwise, construct the pattern based on the valid extensions.
+	const exts = options.extensions
+		.map((extension) => {
+			const chars = Array.from(extension)
+				.slice(1)
+				.map((c) => `[${c.toUpperCase()}${c.toLowerCase()}]`)
+				.join("");
+
+			return `(${chars})`;
+		})
+		.join("|");
+
+	if (options.includeExtension) {
+		// Ensure the value ends with a valid extension
+		pattern += `.*\\.(${exts})$`;
+	} else {
+		// Use a negative look-ahead to ensure the extension isn't specified.
+		pattern += `(?!.*\\.(${exts})$).*$`;
+	}
+
+	return pattern;
+}
+
+/**
+ * Traverses the specified {@link schema} and applies the visitor to each property.
+ * @param schema Schema to traverse
+ * @param visitor Visitor to each of the schema's properties.
+ */
+function visitNode(schema: ExtendedSchema, visitor: (schema: ExtendedSchema, keyword: keyof ExtendedSchema, value: unknown) => void): void {
 	if (typeof schema === "object") {
-		for (const [prop, value] of Object.entries(schema)) {
+		for (const [keyword, value] of Object.entries(schema)) {
 			if (typeof value === "object") {
-				addMarkdownDescription(value);
+				visitNode(value, visitor);
 			}
 
-			if (prop === "description") {
-				schema.markdownDescription = value;
-			}
+			visitor(schema, keyword as keyof ExtendedSchema, value);
 		}
 	}
 }
@@ -56,7 +123,28 @@ function addMarkdownDescription(schema: ExtendedSchema): void {
  */
 type ExtendedSchema = Schema & {
 	/**
+	 * Determines whether the value must represent a file path.
+	 */
+	filePath?: FilePathOptions;
+
+	/**
 	 * Markdown representation of the description.
 	 */
 	markdownDescription?: string;
 };
+
+/**
+ * Options used to determine a valid file path, used to generate the regular expression pattern.
+ */
+type FilePathOptions =
+	| boolean
+	| {
+			/**
+			 * Collection of valid file extensions.
+			 */
+			extensions: string[];
+			/**
+			 * Determines whether the extension must be present, or omitted, from the file path.
+			 */
+			includeExtension: boolean;
+	  };

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -131,10 +131,22 @@ export type Manifest = {
 			 * **Examples:**
 			 * - $A1
 			 * - layouts/my-custom-layout.json
-			 * @examples
-			 * [ "$X1", "$A0", "$A1", "$B1", "$B2", "$C1" ]
+			 * @example
+			 * "$X1"
+			 * @example
+			 * "$A0"
+			 * @example
+			 * "$A1"
+			 * @example
+			 * "$B1"
+			 * @example
+			 * "$B2"
+			 * @example
+			 * "$C1"
+			 * @example
+			 * "custom.json"
 			 * @pattern
-			 * (^(\$[AB][12])|(\$[XC]1))$|(^(?!\/).+\.[Jj][Ss][Oo][Nn]$)
+			 * ^((?![\.]*[\\\/]+).*\.([Jj][Ss][Oo][Nn]))|(\$(X1|A0|A1|B1|B2|C1))$
 			 */
 			layout?: FilePath<"json"> | "$A0" | "$A1" | "$B1" | "$B2" | "$C1" | "$X1";
 		};

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -463,16 +463,18 @@ export type Manifest = {
 	URL?: string;
 
 	/**
-	 * Version of the plugin, represented as a {@link https://semver.org semantic version} (excluding pre-release values).
+	 * Version of the plugin, represented as a semantic version, excluding pre-release values (https://semver.org). The version can also include an optional build number.
 	 *
 	 * **Examples:**
 	 * - 1.0.3 ✅
-	 * - 0.0.99 ✅
+	 * - 0.0.99.123 ✅
 	 * - 2.1.9-beta1 ❌
 	 * @example
 	 * "1.0.0"
+	 * @pattern
+	 * ^\d+(\.\d+){2,3}$
 	 */
-	Version: `${number}.${number}.${number}`;
+	Version: string;
 };
 
 /**

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -67,10 +67,8 @@ export type Manifest = {
 			 * - #d60270
 			 * - #1f1f1
 			 * - #0038a8
-			 * @pattern
-			 * ^#(?:[0-9a-fA-F]{3}){1,2}$
 			 */
-			StackColor?: string;
+			StackColor?: HexColorString;
 
 			/**
 			 * Descriptions that define the interaction of the action when it is associated with a dial / touchscreen on the Stream Deck+. This information is shown to the user.
@@ -147,6 +145,8 @@ export type Manifest = {
 			 * "custom.json"
 			 * @pattern
 			 * ^((?![\.]*[\\\/]+).*\.([Jj][Ss][Oo][Nn]))|(\$(X1|A0|A1|B1|B2|C1))$
+			 * @errorMessage
+			 * String must be a pre-defined layout, or a .json file located within the plugin's directory
 			 */
 			layout?: FilePath<"json"> | "$A0" | "$A1" | "$B1" | "$B2" | "$C1" | "$X1";
 		};
@@ -217,6 +217,8 @@ export type Manifest = {
 		 * - tv.twitch.go-live
 		 * @pattern
 		 * ^([a-z0-9\-_]+)(\.[a-z0-9\-_]+)+$
+		 * @errorMessage
+		 * String must use reverse DNS format, and must only contain lowercase alphanumeric characters (a-z, 0-9), hyphens (-), underscores (_), and periods (.)
 		 */
 		UUID: string;
 
@@ -486,9 +488,20 @@ export type Manifest = {
 	 * "1.0.0"
 	 * @pattern
 	 * ^\d+(\.\d+){2,3}$
+	 * @errorMessage
+	 * String must be a semantic version (pre-releases are not permitted)
 	 */
 	Version: string;
 };
+
+/**
+ * Color represents as a hexadecimal string.
+ * @pattern
+ * ^#(?:[0-9a-fA-F]{3}){1,2}$
+ * @errorMessage
+ * String must be hexadecimal color.
+ */
+type HexColorString = string;
 
 /**
  * File path that represents an HTML file relative to the plugin's manifest.
@@ -618,10 +631,8 @@ type ActionState = {
 	 * - #5bcefa
 	 * - #f5a9b8
 	 * - #FFFFFF
-	 * @pattern
-	 * ^#(?:[0-9a-fA-F]{3}){1,2}$
 	 */
-	TitleColor?: string;
+	TitleColor?: HexColorString;
 };
 
 let manifest: Omit<Manifest, "$schema">;

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -23,6 +23,7 @@ export type Manifest = {
 		/**
 		 * Defines the controller type the action is applicable to. **Keypad** refers to a standard action on a Stream Deck device, e.g. 1 of the 15 buttons on the Stream Deck MK.2,
 		 * or a pedal on the Stream Deck Pedal, etc., whereas an **Encoder** refers to a dial / touchscreen on the Stream Deck+.
+		 * @uniqueItems
 		 */
 		Controllers?: [Controller, Controller?];
 

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -204,7 +204,7 @@ export type Manifest = {
 		 * - com.elgato.discord.join-voice
 		 * - tv.twitch.go-live
 		 * @pattern
-		 * ^([a-z0-9\-_]*[a-z0-9][a-z0-9\-_]*\.){2,3}[a-z0-9\-_]*[a-z0-9][a-z0-9\-_]*$
+		 * ^([a-z0-9\-_]+)(\.[a-z0-9\-_]+)+$
 		 */
 		UUID: string;
 

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -57,7 +57,7 @@ export type Manifest = {
 			 * - assets/actions/mute/encoder-icon
 			 * - imgs/join-voice-chat-encoder
 			 */
-			Icon?: FilePathWithoutExtension;
+			Icon?: ImageFilePath;
 
 			/**
 			 * Background color to display in the Stream Deck application when the action is part of a dial stack, and is the current action. Represented as a hexadecimal value.
@@ -111,8 +111,10 @@ export type Manifest = {
 			 * **Examples:**
 			 * - assets/backgrounds/main
 			 * - imgs/bright-blue-bg
+			 * @filePath
+			 * { extensions: [".png", ".svg"], includeExtension: false }
 			 */
-			background?: FilePathWithoutExtension;
+			background?: string;
 
 			/**
 			 * Name of a pre-defined layout, or the path to a JSON file that details a custom layout and its components, to be rendered on the action's touchscreen canvas.
@@ -147,7 +149,7 @@ export type Manifest = {
 		 * - assets/counter
 		 * - imgs/actions/mute
 		 */
-		Icon: FilePathWithoutExtension;
+		Icon: ImageFilePath;
 
 		/**
 		 * Name of the action; this is displayed to the user in the actions list, and is used throughout the Stream Deck application to visually identify the action.
@@ -266,8 +268,10 @@ export type Manifest = {
 	 * **Examples**:
 	 * - assets/category-icon
 	 * - imgs/category
+	 * @filePath
+	 * { extensions: [".svg", ".png"], includeExtension: false }
 	 */
-	CategoryIcon?: FilePathWithoutExtension;
+	CategoryIcon?: string;
 
 	/**
 	 * Path to the plugin's main entry point; this is executed when the Stream Deck application starts the plugin.
@@ -276,6 +280,7 @@ export type Manifest = {
 	 * - index.js
 	 * - Counter
 	 * - Counter.exe
+	 * @filePath
 	 */
 	CodePath: string;
 
@@ -285,6 +290,7 @@ export type Manifest = {
 	 * **Examples:**
 	 * - index.js
 	 * - Counter
+	 * @filePath
 	 */
 	CodePathMac?: string;
 
@@ -294,6 +300,7 @@ export type Manifest = {
 	 * **Examples:**
 	 * - index.js
 	 * - Counter.exe
+	 * @filePath
 	 */
 	CodePathWin?: string;
 
@@ -319,7 +326,7 @@ export type Manifest = {
 	 * assets/plugin-icon
 	 * imgs/plugin
 	 */
-	Icon: FilePathWithoutExtension;
+	Icon: ImageFilePath;
 
 	/**
 	 * Name of the plugin, e.g. "Wave Link", "Camera Hub", "Control Center", etc.
@@ -405,6 +412,8 @@ export type Manifest = {
 		 * **Examples:**
 		 * - assets/main-profile
 		 * - profiles/super-cool-profile
+		 * @filePath
+		 * { extensions: [".streamDeckProfile"], includeExtension: false }
 		 */
 		Name: string;
 
@@ -468,17 +477,17 @@ export type Manifest = {
 
 /**
  * File path that represents an HTML file relative to the plugin's manifest.
- * @pattern
- * ^(?!\/).+\.[Hh][Tt][Mm][Ll]?$
+ * @filePath
+ * { extensions: [".htm", ".html"], includeExtension: true }
  */
 type HtmlFilePath = FilePath<"htm" | "html">;
 
 /**
- * File path that represents a file relative to the plugin's manifest, with the extension omitted.
- * @pattern
- * ^[^.]+$
+ * File path that represents a file relative to the plugin's manifest, with the extension omitted. When multiple images with the same name are found, they are resolved in order.
+ * @filePath
+ * { extensions: [".gif", ".svg", ".png"], includeExtension: false }
  */
-type FilePathWithoutExtension = string;
+type ImageFilePath = string;
 
 /**
  * File path, relative to the manifest's location.
@@ -544,7 +553,7 @@ type ActionState = {
 	 * - assets/counter-key
 	 * - assets/icons/mute
 	 */
-	Image: FilePathWithoutExtension;
+	Image: ImageFilePath;
 
 	/**
 	 * Path to the image, with the **file extension omitted**, that will be displayed when the action is being viewed as part of a multi-action. The image must adhere to the following
@@ -558,7 +567,7 @@ type ActionState = {
 	 * - assets/counter-key
 	 * - assets/icons/mute
 	 */
-	MultiActionImage?: FilePathWithoutExtension;
+	MultiActionImage?: ImageFilePath;
 
 	/**
 	 * Name of the state; when multiple states are defined this value is shown to the user when the action is being added to a multi-action. The user is then able to specify which


### PR DESCRIPTION
- Prevent file paths with leading slashes and/or periods.
- Automate pattern generation for file paths with, and without, extensions.
- Update UUID pattern, allowing for more than 3 segments.
- Fix pre-defined layout `$A0` not being valid, and remove `$A2`.
- Prevent duplicate items in `Actions[].Controllers`
- Add file path validation for `CodePath`, `CodePathMac`, and `CodePathWin`.
- Add validation of `Version`.