### PR TITLE
fix: manifest schema validation

### DIFF
--- a/schemas/manifest.json
+++ b/schemas/manifest.json
@@ -121,7 +121,7 @@
 											"$C1",
 											"custom.json"
 										],
-										"pattern": "^((?![\\.]*[\\\\\\/]+).*\\.([Jj][Ss][Oo][Nn]))|(\\$(X1|A0|A1|B1|B2|C1))$",
+										"pattern": "^(^(?![\\.]*[\\\\\\/]+).+\\.([Jj][Ss][Oo][Nn])$)|(\\$(X1|A0|A1|B1|B2|C1))$",
 										"errorMessage": "String must be a pre-defined layout, or a .json file located within the plugin's directory",
 										"markdownDescription": "Name of a pre-defined layout, or the path to a JSON file that details a custom layout and its components, to be rendered on the action's touchscreen canvas.\n\n**Pre-defined Layouts:**\n- `$X1`, layout with the title at the top and the icon beneath it in the center.\n- `$A0`, layout with the title at the top and a full-width image canvas beneath it in the center.\n- `$A1`, layout with the title at the top, the icon on the left, and text value on the right.\n- `$B1`, layout with the title at the top, the icon on the left, and a text value on the right with a progress bar beneath it.\n- `$B2`, layout with the title at the top, the icon on the left, and a text value on the right with a gradient progress bar beneath it.\n- `$C1`, layout with the title at the top, and two rows that display an icon on the left and progress bar on the right (i.e. a double progress bar layout).\n\n**Examples:**\n- $A1\n- layouts/my-custom-layout.json"
 									}

--- a/schemas/manifest.json
+++ b/schemas/manifest.json
@@ -581,6 +581,13 @@
 					"description": "Link to the plugin's website.\n\n**Examples**:\n- https://elgato.com\n- https://corsair.com",
 					"markdownDescription": "Link to the plugin's website.\n\n**Examples**:\n- https://elgato.com\n- https://corsair.com"
 				},
+				"UUID": {
+					"type": "string",
+					"description": "Unique identifier of the plugin, represented in reverse-DNS format.\n\n**Allowed characters:**\n- Lowercase alphanumeric characters (a-z, 0-9)\n- Hyphens (-)\n- Underscores (_)\n- Periods (.)\n\n**Examples:**\n- com.elgato.wavelink\n- com.elgato.discord\n- tv.twitch",
+					"pattern": "^([a-z0-9\\-_]+)(\\.[a-z0-9\\-_]+)+$",
+					"errorMessage": "String must use reverse DNS format, and must only contain lowercase alphanumeric characters (a-z, 0-9), hyphens (-), underscores (_), and periods (.)",
+					"markdownDescription": "Unique identifier of the plugin, represented in reverse-DNS format.\n\n**Allowed characters:**\n- Lowercase alphanumeric characters (a-z, 0-9)\n- Hyphens (-)\n- Underscores (_)\n- Periods (.)\n\n**Examples:**\n- com.elgato.wavelink\n- com.elgato.discord\n- tv.twitch"
+				},
 				"Version": {
 					"type": "string",
 					"description": "Version of the plugin, represented as a semantic version, excluding pre-release values (https://semver.org). The version can also include an optional build number.\n\n**Examples:**\n- 1.0.3 ✅\n- 0.0.99.123 ✅\n- 2.1.9-beta1 ❌",
@@ -602,6 +609,7 @@
 				"OS",
 				"SDKVersion",
 				"Software",
+				"UUID",
 				"Version"
 			],
 			"additionalProperties": false,

--- a/schemas/manifest.json
+++ b/schemas/manifest.json
@@ -50,15 +50,14 @@
 										"description": "Path to the image, with the **file extension omitted**, that will be displayed in the Stream Deck application in the circular canvas that represents the dial of the action. The image must fulfill the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 72x72 px and 144x144 px (@2x).\n\nNB: Can be overridden by the user in the Stream Deck application.\n\n**Examples:**\n- assets/actions/mute/encoder-icon\n- imgs/join-voice-chat-encoder",
 										"filePath": {
 											"extensions": [
-												".gif",
 												".svg",
 												".png"
 											],
 											"includeExtension": false
 										},
 										"markdownDescription": "Path to the image, with the **file extension omitted**, that will be displayed in the Stream Deck application in the circular canvas that represents the dial of the action. The image must fulfill the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 72x72 px and 144x144 px (@2x).\n\nNB: Can be overridden by the user in the Stream Deck application.\n\n**Examples:**\n- assets/actions/mute/encoder-icon\n- imgs/join-voice-chat-encoder",
-										"pattern": "^(?![~\\.]*[\\\\\\/]+)(?!.*\\.(([Gg][Ii][Ff])|([Ss][Vv][Gg])|([Pp][Nn][Gg]))$).*$",
-										"errorMessage": "String must be a .gif, .svg, or .png file located within the plugin's directory, with the file extension omitted"
+										"pattern": "^(?![~\\.]*[\\\\\\/]+)(?!.*\\.(([Ss][Vv][Gg])|([Pp][Nn][Gg]))$).*$",
+										"errorMessage": "String must be a .svg, or .png file located within the plugin's directory, with the file extension omitted"
 									},
 									"StackColor": {
 										"type": "string",
@@ -135,15 +134,14 @@
 								"description": "Path to the image, with the **file extension omitted**, that will be displayed next to the action in the Stream Deck application's action list. The image must adhere to the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 20x20 px and 40x40 px (@2x).\n- Be monochromatic, with foreground color of #EFEFEF and a transparent background.\n\n**Examples:**\n- assets/counter\n- imgs/actions/mute",
 								"filePath": {
 									"extensions": [
-										".gif",
 										".svg",
 										".png"
 									],
 									"includeExtension": false
 								},
 								"markdownDescription": "Path to the image, with the **file extension omitted**, that will be displayed next to the action in the Stream Deck application's action list. The image must adhere to the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 20x20 px and 40x40 px (@2x).\n- Be monochromatic, with foreground color of #EFEFEF and a transparent background.\n\n**Examples:**\n- assets/counter\n- imgs/actions/mute",
-								"pattern": "^(?![~\\.]*[\\\\\\/]+)(?!.*\\.(([Gg][Ii][Ff])|([Ss][Vv][Gg])|([Pp][Nn][Gg]))$).*$",
-								"errorMessage": "String must be a .gif, .svg, or .png file located within the plugin's directory, with the file extension omitted"
+								"pattern": "^(?![~\\.]*[\\\\\\/]+)(?!.*\\.(([Ss][Vv][Gg])|([Pp][Nn][Gg]))$).*$",
+								"errorMessage": "String must be a .svg, or .png file located within the plugin's directory, with the file extension omitted"
 							},
 							"Name": {
 								"type": "string",
@@ -198,7 +196,7 @@
 										},
 										"Image": {
 											"type": "string",
-											"description": "Path to the image, with the **file extension omitted**, that will be displayed on the Stream Deck when this action's state is active. The image must adhere to the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 72x72 px and 144x144 px (@2x).\n\nNB: Can be overridden by the user in the Stream Deck application.\n\n**Examples:**\n- assets/counter-key\n- assets/icons/mute",
+											"description": "Path to the image, with the **file extension omitted**, that will be displayed on the Stream Deck when this action's state is active. The image must adhere to the following style guidelines.\n- Be in .GIF, .PNG or .SVG format.\n- Be provided in two sizes, 72x72 px and 144x144 px (@2x).\n\nNB: Can be overridden by the user in the Stream Deck application.\n\n**Examples:**\n- assets/counter-key\n- assets/icons/mute",
 											"filePath": {
 												"extensions": [
 													".gif",
@@ -207,7 +205,7 @@
 												],
 												"includeExtension": false
 											},
-											"markdownDescription": "Path to the image, with the **file extension omitted**, that will be displayed on the Stream Deck when this action's state is active. The image must adhere to the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 72x72 px and 144x144 px (@2x).\n\nNB: Can be overridden by the user in the Stream Deck application.\n\n**Examples:**\n- assets/counter-key\n- assets/icons/mute",
+											"markdownDescription": "Path to the image, with the **file extension omitted**, that will be displayed on the Stream Deck when this action's state is active. The image must adhere to the following style guidelines.\n- Be in .GIF, .PNG or .SVG format.\n- Be provided in two sizes, 72x72 px and 144x144 px (@2x).\n\nNB: Can be overridden by the user in the Stream Deck application.\n\n**Examples:**\n- assets/counter-key\n- assets/icons/mute",
 											"pattern": "^(?![~\\.]*[\\\\\\/]+)(?!.*\\.(([Gg][Ii][Ff])|([Ss][Vv][Gg])|([Pp][Nn][Gg]))$).*$",
 											"errorMessage": "String must be a .gif, .svg, or .png file located within the plugin's directory, with the file extension omitted"
 										},
@@ -216,15 +214,14 @@
 											"description": "Path to the image, with the **file extension omitted**, that will be displayed when the action is being viewed as part of a multi-action. The image must adhere to the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 72x72 px and 144x144 px (@2x).\n\nNB: Can be overridden by the user in the Stream Deck application.\n\n**Examples:**\n- assets/counter-key\n- assets/icons/mute",
 											"filePath": {
 												"extensions": [
-													".gif",
 													".svg",
 													".png"
 												],
 												"includeExtension": false
 											},
 											"markdownDescription": "Path to the image, with the **file extension omitted**, that will be displayed when the action is being viewed as part of a multi-action. The image must adhere to the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 72x72 px and 144x144 px (@2x).\n\nNB: Can be overridden by the user in the Stream Deck application.\n\n**Examples:**\n- assets/counter-key\n- assets/icons/mute",
-											"pattern": "^(?![~\\.]*[\\\\\\/]+)(?!.*\\.(([Gg][Ii][Ff])|([Ss][Vv][Gg])|([Pp][Nn][Gg]))$).*$",
-											"errorMessage": "String must be a .gif, .svg, or .png file located within the plugin's directory, with the file extension omitted"
+											"pattern": "^(?![~\\.]*[\\\\\\/]+)(?!.*\\.(([Ss][Vv][Gg])|([Pp][Nn][Gg]))$).*$",
+											"errorMessage": "String must be a .svg, or .png file located within the plugin's directory, with the file extension omitted"
 										},
 										"Name": {
 											"type": "string",
@@ -408,15 +405,14 @@
 					"description": "Path to the image, with the **file extension omitted**, that will be displayed on the Marketplace. The icon should accurately represent the plugin, stand out, and enable users to quickly identify the plugin. The icon must adhere to the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 288x288 px and 512x512 px (@2x).\n\n**Examples**: assets/plugin-icon imgs/plugin",
 					"filePath": {
 						"extensions": [
-							".gif",
 							".svg",
 							".png"
 						],
 						"includeExtension": false
 					},
 					"markdownDescription": "Path to the image, with the **file extension omitted**, that will be displayed on the Marketplace. The icon should accurately represent the plugin, stand out, and enable users to quickly identify the plugin. The icon must adhere to the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 288x288 px and 512x512 px (@2x).\n\n**Examples**: assets/plugin-icon imgs/plugin",
-					"pattern": "^(?![~\\.]*[\\\\\\/]+)(?!.*\\.(([Gg][Ii][Ff])|([Ss][Vv][Gg])|([Pp][Nn][Gg]))$).*$",
-					"errorMessage": "String must be a .gif, .svg, or .png file located within the plugin's directory, with the file extension omitted"
+					"pattern": "^(?![~\\.]*[\\\\\\/]+)(?!.*\\.(([Ss][Vv][Gg])|([Pp][Nn][Gg]))$).*$",
+					"errorMessage": "String must be a .svg, or .png file located within the plugin's directory, with the file extension omitted"
 				},
 				"Name": {
 					"type": "string",

--- a/schemas/manifest.json
+++ b/schemas/manifest.json
@@ -57,7 +57,7 @@
 										},
 										"markdownDescription": "Path to the image, with the **file extension omitted**, that will be displayed in the Stream Deck application in the circular canvas that represents the dial of the action. The image must fulfill the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 72x72 px and 144x144 px (@2x).\n\nNB: Can be overridden by the user in the Stream Deck application.\n\n**Examples:**\n- assets/actions/mute/encoder-icon\n- imgs/join-voice-chat-encoder",
 										"pattern": "^(?![~\\.]*[\\\\\\/]+)(?!.*\\.(([Ss][Vv][Gg])|([Pp][Nn][Gg]))$).*$",
-										"errorMessage": "String must be a .svg, or .png file located within the plugin's directory, with the file extension omitted"
+										"errorMessage": "String must reference .svg, or .png file in the plugin directory, with the file extension omitted."
 									},
 									"StackColor": {
 										"type": "string",
@@ -106,7 +106,7 @@
 										},
 										"markdownDescription": "Path to the image, with the **file extension omitted**, that will be displayed on the touchscreen behind the action's layout. The image must fulfill the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 200x100 px and 400x200 px (@2x).\n\nNB: Can be overridden by the user in the Stream Deck application.\n\n**Examples:**\n- assets/backgrounds/main\n- imgs/bright-blue-bg",
 										"pattern": "^(?![~\\.]*[\\\\\\/]+)(?!.*\\.(([Pp][Nn][Gg])|([Ss][Vv][Gg]))$).*$",
-										"errorMessage": "String must be a .png, or .svg file located within the plugin's directory, with the file extension omitted"
+										"errorMessage": "String must reference .png, or .svg file in the plugin directory, with the file extension omitted."
 									},
 									"layout": {
 										"type": "string",
@@ -121,7 +121,7 @@
 											"custom.json"
 										],
 										"pattern": "^(^(?![\\.]*[\\\\\\/]+).+\\.([Jj][Ss][Oo][Nn])$)|(\\$(X1|A0|A1|B1|B2|C1))$",
-										"errorMessage": "String must be a pre-defined layout, or a .json file located within the plugin's directory",
+										"errorMessage": "String must reference .json file in the plugin directory, or a pre-defined layout.",
 										"markdownDescription": "Name of a pre-defined layout, or the path to a JSON file that details a custom layout and its components, to be rendered on the action's touchscreen canvas.\n\n**Pre-defined Layouts:**\n- `$X1`, layout with the title at the top and the icon beneath it in the center.\n- `$A0`, layout with the title at the top and a full-width image canvas beneath it in the center.\n- `$A1`, layout with the title at the top, the icon on the left, and text value on the right.\n- `$B1`, layout with the title at the top, the icon on the left, and a text value on the right with a progress bar beneath it.\n- `$B2`, layout with the title at the top, the icon on the left, and a text value on the right with a gradient progress bar beneath it.\n- `$C1`, layout with the title at the top, and two rows that display an icon on the left and progress bar on the right (i.e. a double progress bar layout).\n\n**Examples:**\n- $A1\n- layouts/my-custom-layout.json"
 									}
 								},
@@ -141,7 +141,7 @@
 								},
 								"markdownDescription": "Path to the image, with the **file extension omitted**, that will be displayed next to the action in the Stream Deck application's action list. The image must adhere to the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 20x20 px and 40x40 px (@2x).\n- Be monochromatic, with foreground color of #EFEFEF and a transparent background.\n\n**Examples:**\n- assets/counter\n- imgs/actions/mute",
 								"pattern": "^(?![~\\.]*[\\\\\\/]+)(?!.*\\.(([Ss][Vv][Gg])|([Pp][Nn][Gg]))$).*$",
-								"errorMessage": "String must be a .svg, or .png file located within the plugin's directory, with the file extension omitted"
+								"errorMessage": "String must reference .svg, or .png file in the plugin directory, with the file extension omitted."
 							},
 							"Name": {
 								"type": "string",
@@ -160,7 +160,7 @@
 								},
 								"markdownDescription": "Optional path to the HTML file that represents the property inspector for this action; this is displayed to the user in the Stream Deck application when they add the action, allowing them to configure the action's settings. When `undefined`, the manifest's top-level `PropertyInspectorPath` is used, otherwise none.\n\nNB: Path should be relative to the root of the plugin's folder, with no leading slash.\n\n**Examples:**\n- mute.html\n- actions/join-voice-chat/settings.html",
 								"pattern": "^(?![~\\.]*[\\\\\\/]+).*\\.(([Hh][Tt][Mm])|([Hh][Tt][Mm][Ll]))$",
-								"errorMessage": "String must be a .htm, or .html file located within the plugin's directory"
+								"errorMessage": "String must reference .htm, or .html file in the plugin directory."
 							},
 							"States": {
 								"type": "array",
@@ -207,7 +207,7 @@
 											},
 											"markdownDescription": "Path to the image, with the **file extension omitted**, that will be displayed on the Stream Deck when this action's state is active. The image must adhere to the following style guidelines.\n- Be in .GIF, .PNG or .SVG format.\n- Be provided in two sizes, 72x72 px and 144x144 px (@2x).\n\nNB: Can be overridden by the user in the Stream Deck application.\n\n**Examples:**\n- assets/counter-key\n- assets/icons/mute",
 											"pattern": "^(?![~\\.]*[\\\\\\/]+)(?!.*\\.(([Gg][Ii][Ff])|([Ss][Vv][Gg])|([Pp][Nn][Gg]))$).*$",
-											"errorMessage": "String must be a .gif, .svg, or .png file located within the plugin's directory, with the file extension omitted"
+											"errorMessage": "String must reference .gif, .svg, or .png file in the plugin directory, with the file extension omitted."
 										},
 										"MultiActionImage": {
 											"type": "string",
@@ -221,7 +221,7 @@
 											},
 											"markdownDescription": "Path to the image, with the **file extension omitted**, that will be displayed when the action is being viewed as part of a multi-action. The image must adhere to the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 72x72 px and 144x144 px (@2x).\n\nNB: Can be overridden by the user in the Stream Deck application.\n\n**Examples:**\n- assets/counter-key\n- assets/icons/mute",
 											"pattern": "^(?![~\\.]*[\\\\\\/]+)(?!.*\\.(([Ss][Vv][Gg])|([Pp][Nn][Gg]))$).*$",
-											"errorMessage": "String must be a .svg, or .png file located within the plugin's directory, with the file extension omitted"
+											"errorMessage": "String must reference .svg, or .png file in the plugin directory, with the file extension omitted."
 										},
 										"Name": {
 											"type": "string",
@@ -353,7 +353,7 @@
 					},
 					"markdownDescription": "Path to the image, with the **file extension omitted**, that will be displayed next to the action list group within the Stream Deck application. The icon should accurately represent the plugin, and enable users to quickly identify the plugin. The icon must adhere to the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 28x28 px and 56x56 px (@2x).\n- Be monochromatic, with foreground color of #DFDFDF and a transparent background.\n\n**Examples**:\n- assets/category-icon\n- imgs/category",
 					"pattern": "^(?![~\\.]*[\\\\\\/]+)(?!.*\\.(([Ss][Vv][Gg])|([Pp][Nn][Gg]))$).*$",
-					"errorMessage": "String must be a .svg, or .png file located within the plugin's directory, with the file extension omitted"
+					"errorMessage": "String must reference .svg, or .png file in the plugin directory, with the file extension omitted."
 				},
 				"CodePath": {
 					"type": "string",
@@ -361,7 +361,7 @@
 					"filePath": true,
 					"markdownDescription": "Path to the plugin's main entry point; this is executed when the Stream Deck application starts the plugin.\n\n**Examples**:\n- index.js\n- Counter\n- Counter.exe",
 					"pattern": "^(?![~\\.]*[\\\\\\/]+).*$",
-					"errorMessage": "String must be a file located within the plugins's directory"
+					"errorMessage": "String must reference file in the plugin directory."
 				},
 				"CodePathMac": {
 					"type": "string",
@@ -369,7 +369,7 @@
 					"filePath": true,
 					"markdownDescription": "Path to the plugin's entry point specific to macOS; this is executed when the Stream Deck application starts the plugin on macOS.\n\n**Examples:**\n- index.js\n- Counter",
 					"pattern": "^(?![~\\.]*[\\\\\\/]+).*$",
-					"errorMessage": "String must be a file located within the plugins's directory"
+					"errorMessage": "String must reference file in the plugin directory."
 				},
 				"CodePathWin": {
 					"type": "string",
@@ -377,7 +377,7 @@
 					"filePath": true,
 					"markdownDescription": "Path to the plugin's entry point specific to Windows; this is executed when the Stream Deck application starts the plugin on Windows.\n\n**Examples:**\n- index.js\n- Counter.exe",
 					"pattern": "^(?![~\\.]*[\\\\\\/]+).*$",
-					"errorMessage": "String must be a file located within the plugins's directory"
+					"errorMessage": "String must reference file in the plugin directory."
 				},
 				"DefaultWindowSize": {
 					"type": "array",
@@ -412,7 +412,7 @@
 					},
 					"markdownDescription": "Path to the image, with the **file extension omitted**, that will be displayed on the Marketplace. The icon should accurately represent the plugin, stand out, and enable users to quickly identify the plugin. The icon must adhere to the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 288x288 px and 512x512 px (@2x).\n\n**Examples**: assets/plugin-icon imgs/plugin",
 					"pattern": "^(?![~\\.]*[\\\\\\/]+)(?!.*\\.(([Ss][Vv][Gg])|([Pp][Nn][Gg]))$).*$",
-					"errorMessage": "String must be a .svg, or .png file located within the plugin's directory, with the file extension omitted"
+					"errorMessage": "String must reference .svg, or .png file in the plugin directory, with the file extension omitted."
 				},
 				"Name": {
 					"type": "string",
@@ -519,7 +519,7 @@
 								},
 								"markdownDescription": "Path to the `.streamDeckProfile`, with the **file extension omitted**, that contains the profiles layout and action settings.\n\n**Examples:**\n- assets/main-profile\n- profiles/super-cool-profile",
 								"pattern": "^(?![~\\.]*[\\\\\\/]+)(?!.*\\.(([Ss][Tt][Rr][Ee][Aa][Mm][Dd][Ee][Cc][Kk][Pp][Rr][Oo][Ff][Ii][Ll][Ee]))$).*$",
-								"errorMessage": "String must be a .streamDeckProfile file located within the plugin's directory, with the file extension omitted"
+								"errorMessage": "String must reference .streamDeckProfile file in the plugin directory, with the file extension omitted."
 							},
 							"Readonly": {
 								"type": "boolean",
@@ -548,7 +548,7 @@
 					},
 					"markdownDescription": "Optional path to the HTML file that represents the property inspector for all actions; this is displayed to the user in the Stream Deck application when they add an action, allowing them to configure the action's settings.\n\nNB: Path should be relative to the root of the plugin's folder, with no leading slash.\n\n **Examples:**\n- mute.html\n- actions/join-voice-chat/settings.html\n\n**Also see:**\n- `streamDeck.ui.onSendToPlugin(...)`",
 					"pattern": "^(?![~\\.]*[\\\\\\/]+).*\\.(([Hh][Tt][Mm])|([Hh][Tt][Mm][Ll]))$",
-					"errorMessage": "String must be a .htm, or .html file located within the plugin's directory"
+					"errorMessage": "String must reference .htm, or .html file in the plugin directory."
 				},
 				"SDKVersion": {
 					"type": "number",
@@ -588,7 +588,7 @@
 						"1.0.0"
 					],
 					"pattern": "^\\d+(\\.\\d+){2,3}$",
-					"errorMessage": "String must be a semantic version (pre-releases are not permitted)",
+					"errorMessage": "String must be semantic version (pre-releases are not permitted)",
 					"markdownDescription": "Version of the plugin, represented as a semantic version, excluding pre-release values (https://semver.org). The version can also include an optional build number.\n\n**Examples:**\n- 1.0.3 ✅\n- 0.0.99.123 ✅\n- 2.1.9-beta1 ❌"
 				}
 			},

--- a/schemas/manifest.json
+++ b/schemas/manifest.json
@@ -55,6 +55,10 @@
 											],
 											"includeExtension": false
 										},
+										"imageDimensions": [
+											72,
+											72
+										],
 										"markdownDescription": "Path to the image, with the **file extension omitted**, that will be displayed in the Stream Deck application in the circular canvas that represents the dial of the action. The image must fulfill the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 72x72 px and 144x144 px (@2x).\n\nNB: Can be overridden by the user in the Stream Deck application.\n\n**Examples:**\n- assets/actions/mute/encoder-icon\n- imgs/join-voice-chat-encoder",
 										"pattern": "^(?![~\\.]*[\\\\\\/]+)(?!.*\\.(([Ss][Vv][Gg])|([Pp][Nn][Gg]))$).*$",
 										"errorMessage": "String must reference .svg, or .png file in the plugin directory, with the file extension omitted."
@@ -97,6 +101,10 @@
 									"background": {
 										"type": "string",
 										"description": "Path to the image, with the **file extension omitted**, that will be displayed on the touchscreen behind the action's layout. The image must fulfill the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 200x100 px and 400x200 px (@2x).\n\nNB: Can be overridden by the user in the Stream Deck application.\n\n**Examples:**\n- assets/backgrounds/main\n- imgs/bright-blue-bg",
+										"imageDimensions": [
+											200,
+											100
+										],
 										"filePath": {
 											"extensions": [
 												".png",
@@ -139,6 +147,10 @@
 									],
 									"includeExtension": false
 								},
+								"imageDimensions": [
+									20,
+									20
+								],
 								"markdownDescription": "Path to the image, with the **file extension omitted**, that will be displayed next to the action in the Stream Deck application's action list. The image must adhere to the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 20x20 px and 40x40 px (@2x).\n- Be monochromatic, with foreground color of #EFEFEF and a transparent background.\n\n**Examples:**\n- assets/counter\n- imgs/actions/mute",
 								"pattern": "^(?![~\\.]*[\\\\\\/]+)(?!.*\\.(([Ss][Vv][Gg])|([Pp][Nn][Gg]))$).*$",
 								"errorMessage": "String must reference .svg, or .png file in the plugin directory, with the file extension omitted."
@@ -205,6 +217,10 @@
 												],
 												"includeExtension": false
 											},
+											"imageDimensions": [
+												72,
+												72
+											],
 											"markdownDescription": "Path to the image, with the **file extension omitted**, that will be displayed on the Stream Deck when this action's state is active. The image must adhere to the following style guidelines.\n- Be in .GIF, .PNG or .SVG format.\n- Be provided in two sizes, 72x72 px and 144x144 px (@2x).\n\nNB: Can be overridden by the user in the Stream Deck application.\n\n**Examples:**\n- assets/counter-key\n- assets/icons/mute",
 											"pattern": "^(?![~\\.]*[\\\\\\/]+)(?!.*\\.(([Gg][Ii][Ff])|([Ss][Vv][Gg])|([Pp][Nn][Gg]))$).*$",
 											"errorMessage": "String must reference .gif, .svg, or .png file in the plugin directory, with the file extension omitted."
@@ -219,6 +235,10 @@
 												],
 												"includeExtension": false
 											},
+											"imageDimensions": [
+												72,
+												72
+											],
 											"markdownDescription": "Path to the image, with the **file extension omitted**, that will be displayed when the action is being viewed as part of a multi-action. The image must adhere to the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 72x72 px and 144x144 px (@2x).\n\nNB: Can be overridden by the user in the Stream Deck application.\n\n**Examples:**\n- assets/counter-key\n- assets/icons/mute",
 											"pattern": "^(?![~\\.]*[\\\\\\/]+)(?!.*\\.(([Ss][Vv][Gg])|([Pp][Nn][Gg]))$).*$",
 											"errorMessage": "String must reference .svg, or .png file in the plugin directory, with the file extension omitted."
@@ -351,6 +371,10 @@
 						],
 						"includeExtension": false
 					},
+					"imageDimensions": [
+						28,
+						28
+					],
 					"markdownDescription": "Path to the image, with the **file extension omitted**, that will be displayed next to the action list group within the Stream Deck application. The icon should accurately represent the plugin, and enable users to quickly identify the plugin. The icon must adhere to the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 28x28 px and 56x56 px (@2x).\n- Be monochromatic, with foreground color of #DFDFDF and a transparent background.\n\n**Examples**:\n- assets/category-icon\n- imgs/category",
 					"pattern": "^(?![~\\.]*[\\\\\\/]+)(?!.*\\.(([Ss][Vv][Gg])|([Pp][Nn][Gg]))$).*$",
 					"errorMessage": "String must reference .svg, or .png file in the plugin directory, with the file extension omitted."
@@ -410,6 +434,10 @@
 						],
 						"includeExtension": false
 					},
+					"imageDimensions": [
+						288,
+						288
+					],
 					"markdownDescription": "Path to the image, with the **file extension omitted**, that will be displayed on the Marketplace. The icon should accurately represent the plugin, stand out, and enable users to quickly identify the plugin. The icon must adhere to the following style guidelines.\n- Be in .PNG or .SVG format.\n- Be provided in two sizes, 288x288 px and 512x512 px (@2x).\n\n**Examples**: assets/plugin-icon imgs/plugin",
 					"pattern": "^(?![~\\.]*[\\\\\\/]+)(?!.*\\.(([Ss][Vv][Gg])|([Pp][Nn][Gg]))$).*$",
 					"errorMessage": "String must reference .svg, or .png file in the plugin directory, with the file extension omitted."

--- a/scripts/generate-schemas.ts
+++ b/scripts/generate-schemas.ts
@@ -124,19 +124,15 @@ function generatePathPattern(options: FilePathOptions): string {
  */
 function generatePathErrorMessage(options: FilePathOptions): string {
 	if (typeof options === "boolean") {
-		return "String must be a file located within the plugins's directory";
+		return "String must reference file in the plugin directory.";
 	}
 
 	const exts = options.extensions.reduce((prev, current, index) => {
 		return index === 0 ? current : index === options.extensions.length - 1 ? prev + `, or ${current}` : prev + `, ${current}`;
 	}, "");
 
-	const errorMessage = `String must be a ${exts} file located within the plugin's directory`;
-	if (options.includeExtension) {
-		return errorMessage;
-	}
-
-	return `${errorMessage}, with the file extension omitted`;
+	const errorMessage = `String must reference ${exts} file in the plugin directory`;
+	return options.includeExtension ? `${errorMessage}.` : `${errorMessage}, with the file extension omitted.`;
 }
 
 /**

--- a/scripts/generate-schemas.ts
+++ b/scripts/generate-schemas.ts
@@ -5,7 +5,7 @@ import { Schema, createGenerator } from "ts-json-schema-generator";
 
 // Create a generator so we're able to produce multiple schemas.
 const generator = createGenerator({
-	extraTags: ["errorMessage", "filePath"],
+	extraTags: ["errorMessage", "imageDimensions", "filePath"],
 	path: join(__dirname, "../src/index.ts"),
 	skipTypeCheck: true,
 	tsconfig: join(__dirname, "../tsconfig.json")

--- a/scripts/generate-schemas.ts
+++ b/scripts/generate-schemas.ts
@@ -186,6 +186,7 @@ type FilePathOptions =
 			 * Collection of valid file extensions.
 			 */
 			extensions: string[];
+
 			/**
 			 * Determines whether the extension must be present, or omitted, from the file path.
 			 */

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -57,6 +57,8 @@ export type Manifest = {
 			 * **Examples:**
 			 * - assets/actions/mute/encoder-icon
 			 * - imgs/join-voice-chat-encoder
+			 * @imageDimensions
+			 * [72, 72]
 			 */
 			Icon?: ImageFilePath;
 
@@ -110,6 +112,8 @@ export type Manifest = {
 			 * **Examples:**
 			 * - assets/backgrounds/main
 			 * - imgs/bright-blue-bg
+			 * @imageDimensions
+			 * [200, 100]
 			 * @filePath
 			 * { extensions: [".png", ".svg"], includeExtension: false }
 			 */
@@ -161,6 +165,8 @@ export type Manifest = {
 		 * **Examples:**
 		 * - assets/counter
 		 * - imgs/actions/mute
+		 * @imageDimensions
+		 * [20, 20]
 		 */
 		Icon: ImageFilePath;
 
@@ -279,6 +285,8 @@ export type Manifest = {
 	 * **Examples**:
 	 * - assets/category-icon
 	 * - imgs/category
+	 * @imageDimensions
+	 * [28, 28]
 	 */
 	CategoryIcon?: ImageFilePath;
 
@@ -334,6 +342,8 @@ export type Manifest = {
 	 * **Examples**:
 	 * assets/plugin-icon
 	 * imgs/plugin
+	 * @imageDimensions
+	 * [288, 288]
 	 */
 	Icon: ImageFilePath;
 
@@ -528,13 +538,6 @@ type HtmlFilePath = FilePath<"htm" | "html">;
 type ImageFilePath = string;
 
 /**
- * File path that represents a file relative to the plugin's manifest, with the extension omitted. When multiple images with the same name are found, they are resolved in order.
- * @filePath
- * { extensions: [".gif", ".svg", ".png"], includeExtension: false }
- */
-type AnimatedImageFilePath = string;
-
-/**
  * File path, relative to the manifest's location.
  */
 type FilePath<TExt extends string> = `${string}.${Lowercase<TExt>}`;
@@ -606,8 +609,12 @@ type ActionState = {
 	 * **Examples:**
 	 * - assets/counter-key
 	 * - assets/icons/mute
+	 * @filePath
+	 * { extensions: [".gif", ".svg", ".png"], includeExtension: false }
+	 * @imageDimensions
+	 * [72, 72]
 	 */
-	Image: AnimatedImageFilePath;
+	Image: string;
 
 	/**
 	 * Path to the image, with the **file extension omitted**, that will be displayed when the action is being viewed as part of a multi-action. The image must adhere to the following
@@ -620,6 +627,8 @@ type ActionState = {
 	 * **Examples:**
 	 * - assets/counter-key
 	 * - assets/icons/mute
+	 * @imageDimensions
+	 * [72, 72]
 	 */
 	MultiActionImage?: ImageFilePath;
 

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -144,7 +144,7 @@ export type Manifest = {
 			 * @example
 			 * "custom.json"
 			 * @pattern
-			 * ^((?![\.]*[\\\/]+).*\.([Jj][Ss][Oo][Nn]))|(\$(X1|A0|A1|B1|B2|C1))$
+			 * ^(^(?![\.]*[\\\/]+).+\.([Jj][Ss][Oo][Nn])$)|(\$(X1|A0|A1|B1|B2|C1))$
 			 * @errorMessage
 			 * String must be a pre-defined layout, or a .json file located within the plugin's directory
 			 */

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -283,10 +283,8 @@ export type Manifest = {
 	 * **Examples**:
 	 * - assets/category-icon
 	 * - imgs/category
-	 * @filePath
-	 * { extensions: [".svg", ".png"], includeExtension: false }
 	 */
-	CategoryIcon?: string;
+	CategoryIcon?: ImageFilePath;
 
 	/**
 	 * Path to the plugin's main entry point; this is executed when the Stream Deck application starts the plugin.
@@ -513,9 +511,16 @@ type HtmlFilePath = FilePath<"htm" | "html">;
 /**
  * File path that represents a file relative to the plugin's manifest, with the extension omitted. When multiple images with the same name are found, they are resolved in order.
  * @filePath
- * { extensions: [".gif", ".svg", ".png"], includeExtension: false }
+ * { extensions: [".svg", ".png"], includeExtension: false }
  */
 type ImageFilePath = string;
+
+/**
+ * File path that represents a file relative to the plugin's manifest, with the extension omitted. When multiple images with the same name are found, they are resolved in order.
+ * @filePath
+ * { extensions: [".gif", ".svg", ".png"], includeExtension: false }
+ */
+type AnimatedImageFilePath = string;
 
 /**
  * File path, relative to the manifest's location.
@@ -572,7 +577,7 @@ type ActionState = {
 	/**
 	 * Path to the image, with the **file extension omitted**, that will be displayed on the Stream Deck when this action's state is active. The image must adhere to the following
 	 * style guidelines.
-	 * - Be in .PNG or .SVG format.
+	 * - Be in .GIF, .PNG or .SVG format.
 	 * - Be provided in two sizes, 72x72 px and 144x144 px (@2x).
 	 *
 	 * NB: Can be overridden by the user in the Stream Deck application.
@@ -581,7 +586,7 @@ type ActionState = {
 	 * - assets/counter-key
 	 * - assets/icons/mute
 	 */
-	Image: ImageFilePath;
+	Image: AnimatedImageFilePath;
 
 	/**
 	 * Path to the image, with the **file extension omitted**, that will be displayed when the action is being viewed as part of a multi-action. The image must adhere to the following

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -146,7 +146,7 @@ export type Manifest = {
 			 * @pattern
 			 * ^(^(?![\.]*[\\\/]+).+\.([Jj][Ss][Oo][Nn])$)|(\$(X1|A0|A1|B1|B2|C1))$
 			 * @errorMessage
-			 * String must be a pre-defined layout, or a .json file located within the plugin's directory
+			 * String must reference .json file in the plugin directory, or a pre-defined layout.
 			 */
 			layout?: FilePath<"json"> | "$A0" | "$A1" | "$B1" | "$B2" | "$C1" | "$X1";
 		};
@@ -487,7 +487,7 @@ export type Manifest = {
 	 * @pattern
 	 * ^\d+(\.\d+){2,3}$
 	 * @errorMessage
-	 * String must be a semantic version (pre-releases are not permitted)
+	 * String must be semantic version (pre-releases are not permitted)
 	 */
 	Version: string;
 };

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -215,12 +215,8 @@ export type Manifest = {
 		 * - com.elgato.wavelink.toggle-mute
 		 * - com.elgato.discord.join-voice
 		 * - tv.twitch.go-live
-		 * @pattern
-		 * ^([a-z0-9\-_]+)(\.[a-z0-9\-_]+)+$
-		 * @errorMessage
-		 * String must use reverse DNS format, and must only contain lowercase alphanumeric characters (a-z, 0-9), hyphens (-), underscores (_), and periods (.)
 		 */
-		UUID: string;
+		UUID: Identifier;
 
 		/**
 		 * Determines whether the title field is available to the user when viewing the action's property inspector. Setting this to `false` will disable the user from specifying a
@@ -476,6 +472,22 @@ export type Manifest = {
 	URL?: string;
 
 	/**
+	 * Unique identifier of the plugin, represented in reverse-DNS format.
+	 *
+	 * **Allowed characters:**
+	 * - Lowercase alphanumeric characters (a-z, 0-9)
+	 * - Hyphens (-)
+	 * - Underscores (_)
+	 * - Periods (.)
+	 *
+	 * **Examples:**
+	 * - com.elgato.wavelink
+	 * - com.elgato.discord
+	 * - tv.twitch
+	 */
+	UUID: Identifier;
+
+	/**
 	 * Version of the plugin, represented as a semantic version, excluding pre-release values (https://semver.org). The version can also include an optional build number.
 	 *
 	 * **Examples:**
@@ -541,6 +553,15 @@ type OS = {
 	 */
 	Platform: "mac" | "windows";
 };
+
+/**
+ * Unique identifier, in reverse DNS format.
+ * @pattern
+ * ^([a-z0-9\-_]+)(\.[a-z0-9\-_]+)+$
+ * @errorMessage
+ * String must use reverse DNS format, and must only contain lowercase alphanumeric characters (a-z, 0-9), hyphens (-), underscores (_), and periods (.)
+ */
+type Identifier = string;
 
 /**
  * Defines the state of the action; this includes behavior, iconography, typography, etc.


### PR DESCRIPTION
- Fix `Actions[].Encoder.Layout` could be empty.
- Fix images incorrectly accepting `.gif`; should only apply to `Actions[].States[].Image`.
- Update error messages to be more consistent.
- Add plugin `UUID` to manifest and schema.
- Add `imageDimensions` keyword to images in preparation for validating image dimensions via the Maker CLI.