### PR TITLE
fix: update localization lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 -   `Coordinates` type could erroneously have a non-number type for `row`.
 -   Fix support for allowed types within payloads.
+-   Fix localization lookup.
 
 ### ♻️ Update
 
@@ -33,6 +34,7 @@
 
 ### ➡️ Migration
 
+-   Localizations keys are now indexed from the `Localization` node within the translation file.
 -   `PayloadObject<T>` replaced with `JsonObject`.
 -   JSON schemas have been relocated to a dedicated schemas package, [`@elgato/schemas`](https://github.com/elgatosf/schemas).
 

--- a/src/plugin/__tests__/i18n.test.ts
+++ b/src/plugin/__tests__/i18n.test.ts
@@ -127,9 +127,9 @@ describe("I18nProvider", () => {
 	});
 
 	/**
-	 * Asserts {@link I18nProvider} returns an empty string when the resource could not be found in either the current resource, or the default.
+	 * Asserts {@link I18nProvider} returns the key when the resource could not be found in either the current resource, or the default.
 	 */
-	it("returns empty string for unknown key (logMissingKey: true)", () => {
+	it("returns the key for an unknown resource (logMissingKey: true)", () => {
 		// Arrange.
 		jest.spyOn(fs, "readdirSync").mockReturnValue([]);
 		jest.spyOn(fs, "readFileSync").mockReturnValue("{}");
@@ -142,15 +142,15 @@ describe("I18nProvider", () => {
 		const result = i18n.translate("hello");
 
 		// Assert.
-		expect(result).toBe("");
+		expect(result).toBe("hello");
 		expect(spyOnWarn).toHaveBeenCalledTimes(1);
 		expect(spyOnWarn).toHaveBeenCalledWith("Missing translation: hello");
 	});
 
 	/**
-	 * Asserts {@link I18nProvider} returns an empty string when the resource could not be found in either the current resource, or the default.
+	 * Asserts {@link I18nProvider} returns the key when the resource could not be found in either the current resource, or the default.
 	 */
-	it("returns empty string for unknown key (logMissingKey: false)", () => {
+	it("returns the key for an unknown resource (logMissingKey: false)", () => {
 		// Arrange.
 		jest.spyOn(fs, "readdirSync").mockReturnValue([]);
 		jest.spyOn(fs, "readFileSync").mockReturnValue("{}");
@@ -163,7 +163,7 @@ describe("I18nProvider", () => {
 		const result = i18n.translate("hello");
 
 		// Assert.
-		expect(result).toBe("");
+		expect(result).toBe("hello");
 		expect(spyOnWarn).toHaveBeenCalledTimes(0);
 	});
 

--- a/src/plugin/__tests__/i18n.test.ts
+++ b/src/plugin/__tests__/i18n.test.ts
@@ -39,6 +39,8 @@ describe("I18nProvider", () => {
 		jest.spyOn(process, "cwd").mockReturnValue(mockedCwd);
 	});
 
+	afterEach(() => jest.resetAllMocks());
+
 	/**
 	 * Asserts {@link I18nProvider} uses a scoped {@link Logger}.
 	 */
@@ -66,7 +68,8 @@ describe("I18nProvider", () => {
 		const readFileSyncSpy = jest.spyOn(fs, "readFileSync").mockImplementation(() => "{}");
 
 		// Act.
-		new I18nProvider("en", logger);
+		const i18n = new I18nProvider("en", logger);
+		i18n.translate("test");
 
 		// Assert.
 		expect(readFileSyncSpy).toHaveBeenCalledTimes(6);
@@ -152,7 +155,8 @@ describe("I18nProvider", () => {
 		const spyOnError = jest.spyOn(scopedLogger, "error");
 
 		// Act.
-		new I18nProvider("en", logger);
+		const i18n = new I18nProvider("en", logger);
+		i18n.translate("test");
 
 		// Assert.
 		expect(spyOnError).toHaveBeenCalledTimes(1);

--- a/src/plugin/i18n.ts
+++ b/src/plugin/i18n.ts
@@ -21,12 +21,30 @@ export class I18nProvider {
 	private static readonly DEFAULT_LANGUAGE: Language = "en";
 
 	/**
-	 * Private backing field for {@link locales}.
+	 * Private backing field for {@link I18nProvider.locales}.
 	 */
 	private _locales: Map<Language, JsonObject> | undefined;
 
 	/**
+	 * Logger scoped to this class.
+	 */
+	private readonly logger: Logger;
+
+	/**
+	 * Initializes a new instance of the {@link I18nProvider} class.
+	 * @param language The default language to be used when retrieving translations for a given key.
+	 * @param logger Logger responsible for capturing log entries.
+	 */
+	constructor(
+		private readonly language: Language,
+		logger: Logger
+	) {
+		this.logger = logger.createScope("I18nProvider");
+	}
+
+	/**
 	 * Collection of loaded locales and their translations.
+	 * @returns The locales that contains the translations.
 	 */
 	private get locales(): Map<Language, JsonObject> {
 		if (this._locales !== undefined) {
@@ -47,23 +65,6 @@ export class I18nProvider {
 		}
 
 		return (this._locales = locales);
-	}
-
-	/**
-	 * Logger scoped to this class.
-	 */
-	private readonly logger: Logger;
-
-	/**
-	 * Initializes a new instance of the {@link I18nProvider} class.
-	 * @param language The default language to be used when retrieving translations for a given key.
-	 * @param logger Logger responsible for capturing log entries.
-	 */
-	constructor(
-		private readonly language: Language,
-		logger: Logger
-	) {
-		this.logger = logger.createScope("I18nProvider");
 	}
 
 	/**

--- a/src/plugin/i18n.ts
+++ b/src/plugin/i18n.ts
@@ -1,7 +1,7 @@
 import file from "node:fs";
 import path from "node:path";
 
-import { supportedLanguages, type Language, type Manifest } from "../api";
+import { supportedLanguages, type Language } from "../api";
 import { get } from "./common/utils";
 import { Logger } from "./logging";
 
@@ -32,16 +32,14 @@ export class I18nProvider {
 	/**
 	 * Initializes a new instance of the {@link I18nProvider} class.
 	 * @param language The default language to be used when retrieving translations for a given key.
-	 * @param manifest Manifest that accompanies the plugin.
 	 * @param logger Logger responsible for capturing log entries.
 	 */
 	constructor(
 		private readonly language: Language,
-		manifest: Manifest,
 		logger: Logger
 	) {
 		this.logger = logger.createScope("I18nProvider");
-		this.loadLocales(manifest);
+		this.loadLocales();
 	}
 
 	/**
@@ -62,9 +60,8 @@ export class I18nProvider {
 
 	/**
 	 * Loads all known locales from the current working directory.
-	 * @param manifest Manifest that accompanies the plugin.
 	 */
-	private loadLocales(manifest: Manifest): void {
+	private loadLocales(): void {
 		for (const filePath of file.readdirSync(process.cwd())) {
 			const { ext, name } = path.parse(filePath);
 			const lng = name as Language;
@@ -76,12 +73,6 @@ export class I18nProvider {
 				}
 			}
 		}
-
-		// Merge the manifest into the default language, prioritizing explicitly defined resources.
-		this.locales.set(I18nProvider.DEFAULT_LANGUAGE, {
-			...manifest,
-			...(this.locales.get(I18nProvider.DEFAULT_LANGUAGE) || {})
-		});
 	}
 
 	/**
@@ -105,6 +96,8 @@ export class I18nProvider {
 	 * @returns The resource; otherwise the default language's resource, or `undefined`.
 	 */
 	private translateOrDefault(key: string, language: Language = this.language): string | undefined {
+		key = `Localization.${key}`;
+
 		// When the language and default are the same, only check the language.
 		if (language === I18nProvider.DEFAULT_LANGUAGE) {
 			return get(key, this.locales.get(language))?.toString();

--- a/src/plugin/i18n.ts
+++ b/src/plugin/i18n.ts
@@ -57,7 +57,7 @@ export class I18nProvider {
 			this.logger.warn(`Missing translation: ${key}`);
 		}
 
-		return translation || "";
+		return translation || key;
 	}
 
 	/**

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -64,7 +64,7 @@ export const streamDeck = {
 	 * @returns Internalization provider.
 	 */
 	get i18n(): I18nProvider {
-		return (i18n ??= new I18nProvider(this.info.application.language, this.manifest, this.logger));
+		return (i18n ??= new I18nProvider(this.info.application.language, this.logger));
 	},
 
 	/**

--- a/src/plugin/ui/__tests__/route.test.ts
+++ b/src/plugin/ui/__tests__/route.test.ts
@@ -228,7 +228,6 @@ class ActionWithRoutes extends SingletonAction {
 	 */
 	@route("/characters")
 	public getCharacters(req: MessageRequest, res: MessageResponder): Promise<string[]> {
-		console.log("Called spy async");
 		this.spyOnGetCharacters(req, res);
 		return Promise.resolve(["Anduin", "Sylvanas", "Thrall"]);
 	}
@@ -241,7 +240,6 @@ class ActionWithRoutes extends SingletonAction {
 	 */
 	@route("/characters-sync")
 	public getCharactersSync(req: MessageRequest, res: MessageResponder): string[] {
-		console.log("Called spy sync");
 		this.spyOnGetCharactersSync(req, res);
 		return ["Mario", "Luigi", "Peach"];
 	}


### PR DESCRIPTION
- Localizations lookup now uses the `Localization` node as the prefix of a localization key.
- If a translation does not exist, the key is now returned instead of `undefined`. 