### PR TITLE
fix: prevent exposing routing of internal handlers

### DIFF
--- a/src/common/logging/__tests__/routing.test.ts
+++ b/src/common/logging/__tests__/routing.test.ts
@@ -2,10 +2,11 @@ import type { LogEntry } from "..";
 import { MessageGateway, MessageResponder, type MessageRequestOptions } from "../../messaging";
 import { LogLevel } from "../level";
 import { Logger } from "../logger";
-
-import { LOGGING_WRITE_ROUTE, createRoutedLogTarget, registerCreateLogEntryRoute, type JsonSafeLogEntry } from "../routing";
+import { createRoutedLogTarget, registerCreateLogEntryRoute, type JsonSafeLogEntry } from "../routing";
 
 jest.mock("../../messaging");
+
+const expectedLoggerWritePath = "internal:logger.write";
 
 describe("createRoutedLogTarget", () => {
 	it("sends log entry to router", () => {
@@ -28,7 +29,7 @@ describe("createRoutedLogTarget", () => {
 				message: "Hello world",
 				scope: "Test"
 			} satisfies JsonSafeLogEntry,
-			path: LOGGING_WRITE_ROUTE,
+			path: expectedLoggerWritePath,
 			unidirectional: true
 		});
 	});
@@ -47,7 +48,7 @@ describe("registerCreateLogEntryRoute", () => {
 			spyOnRoute.mock.calls[0][1](
 				{
 					action: jest.fn(),
-					path: LOGGING_WRITE_ROUTE,
+					path: expectedLoggerWritePath,
 					unidirectional: true,
 					body: undefined
 				},
@@ -56,7 +57,7 @@ describe("registerCreateLogEntryRoute", () => {
 
 			// Assert.
 			expect(spyOnRoute).toHaveBeenCalledTimes(1);
-			expect(spyOnRoute).toHaveBeenCalledWith(LOGGING_WRITE_ROUTE, expect.any(Function));
+			expect(spyOnRoute).toHaveBeenCalledWith(expectedLoggerWritePath, expect.any(Function));
 			expect(responder.fail).toHaveBeenCalledTimes(1);
 		});
 
@@ -71,7 +72,7 @@ describe("registerCreateLogEntryRoute", () => {
 			spyOnRoute.mock.calls[0][1](
 				{
 					action: jest.fn(),
-					path: LOGGING_WRITE_ROUTE,
+					path: expectedLoggerWritePath,
 					unidirectional: true,
 					body: {
 						level: undefined
@@ -82,7 +83,7 @@ describe("registerCreateLogEntryRoute", () => {
 
 			// Assert.
 			expect(spyOnRoute).toHaveBeenCalledTimes(1);
-			expect(spyOnRoute).toHaveBeenCalledWith(LOGGING_WRITE_ROUTE, expect.any(Function));
+			expect(spyOnRoute).toHaveBeenCalledWith(expectedLoggerWritePath, expect.any(Function));
 			expect(responder.fail).toHaveBeenCalledTimes(1);
 		});
 	});
@@ -105,7 +106,7 @@ describe("registerCreateLogEntryRoute", () => {
 		spyOnRoute.mock.calls[0][1](
 			{
 				action: jest.fn(),
-				path: LOGGING_WRITE_ROUTE,
+				path: expectedLoggerWritePath,
 				unidirectional: true,
 				body: {
 					level: LogLevel.WARN,
@@ -118,7 +119,7 @@ describe("registerCreateLogEntryRoute", () => {
 
 		// Assert.
 		expect(spyOnRoute).toHaveBeenCalledTimes(1);
-		expect(spyOnRoute).toHaveBeenCalledWith(LOGGING_WRITE_ROUTE, expect.any(Function));
+		expect(spyOnRoute).toHaveBeenCalledWith(expectedLoggerWritePath, expect.any(Function));
 		expect(spyOnWrite).toHaveBeenCalledTimes(1);
 		expect(spyOnWrite).toHaveBeenCalledWith<[LogEntry]>({
 			data: ["Hello world"],

--- a/src/common/logging/routing.ts
+++ b/src/common/logging/routing.ts
@@ -1,9 +1,9 @@
-import type { MessageGateway } from "../messaging";
+import { INTERNAL_PATH_PREFIX, type MessageGateway } from "../messaging";
 import { stringFormatter } from "./format";
 import type { Logger } from "./logger";
 import type { LogEntry, LogTarget } from "./target";
 
-export const LOGGING_WRITE_ROUTE = "#internal:logger.write";
+const LOGGER_WRITE_PATH = `${INTERNAL_PATH_PREFIX}logger.write`;
 
 /**
  * Creates a log target that that sends the log entry to the router.
@@ -21,7 +21,7 @@ export function createRoutedLogTarget(router: MessageGateway<unknown>): LogTarge
 					message: format(entry),
 					scope: entry.scope
 				} satisfies JsonSafeLogEntry,
-				path: LOGGING_WRITE_ROUTE,
+				path: LOGGER_WRITE_PATH,
 				unidirectional: true
 			});
 		}
@@ -34,7 +34,7 @@ export function createRoutedLogTarget(router: MessageGateway<unknown>): LogTarge
  * @param logger Logger responsible for logging log entries.
  */
 export function registerCreateLogEntryRoute(router: MessageGateway<unknown>, logger: Logger): void {
-	router.route<JsonSafeLogEntry>(LOGGING_WRITE_ROUTE, (req, res) => {
+	router.route<JsonSafeLogEntry>(LOGGER_WRITE_PATH, (req, res) => {
 		if (req.body === undefined) {
 			return res.fail();
 		}

--- a/src/common/messaging/gateway.ts
+++ b/src/common/messaging/gateway.ts
@@ -10,6 +10,9 @@ import { MessageResponder } from "./responder";
  */
 const DEFAULT_TIMEOUT = 5000;
 
+export const PUBLIC_PATH_PREFIX = "public:";
+export const INTERNAL_PATH_PREFIX = "internal:";
+
 /**
  * Message gateway responsible for sending, routing, and receiving requests and responses.
  */

--- a/src/plugin/ui/__tests__/controller.test.ts
+++ b/src/plugin/ui/__tests__/controller.test.ts
@@ -153,6 +153,6 @@ describe("UIController", () => {
 
 		// Assert.
 		expect(spyOnRoute).toHaveBeenCalledTimes(1);
-		expect(spyOnRoute).toHaveBeenCalledWith("/register", handler, options);
+		expect(spyOnRoute).toHaveBeenCalledWith("public:/register", handler, options);
 	});
 });

--- a/src/plugin/ui/__tests__/property-inspector.test.ts
+++ b/src/plugin/ui/__tests__/property-inspector.test.ts
@@ -45,7 +45,7 @@ describe("PropertyInspector", () => {
 
 			// Assert.
 			expect(spyOnFetch).toBeCalledTimes(1);
-			expect(spyOnFetch).toHaveBeenLastCalledWith<[string, JsonValue]>("/hello", { name: "Elgato" });
+			expect(spyOnFetch).toHaveBeenLastCalledWith<[string, JsonValue]>("public:/hello", { name: "Elgato" });
 		});
 
 		/**
@@ -71,7 +71,7 @@ describe("PropertyInspector", () => {
 			// Assert.
 			expect(spyOnFetch).toBeCalledTimes(1);
 			expect(spyOnFetch).toHaveBeenLastCalledWith<[MessageRequestOptions]>({
-				path: "/hello",
+				path: "public:/hello",
 				body: { name: "Elgato" },
 				timeout: 1000,
 				unidirectional: true

--- a/src/plugin/ui/__tests__/route.test.ts
+++ b/src/plugin/ui/__tests__/route.test.ts
@@ -31,7 +31,7 @@ describe("route", () => {
 			action.spyOnGetCharacters.mockImplementation(() => awaiter.setResult(true));
 
 			// Act.
-			const res = await piRouter.fetch("/characters", {
+			const res = await piRouter.fetch("public:/characters", {
 				game: "World of Warcraft"
 			});
 
@@ -41,7 +41,7 @@ describe("route", () => {
 			expect(action.spyOnGetCharacters).toHaveBeenLastCalledWith<[MessageRequest<Filter>, MessageResponder]>(
 				{
 					action: new Action(ev),
-					path: "/characters",
+					path: "public:/characters",
 					unidirectional: false,
 					body: {
 						game: "World of Warcraft"
@@ -65,7 +65,7 @@ describe("route", () => {
 			action.spyOnGetCharactersSync.mockImplementation(() => awaiter.setResult(true));
 
 			// Act.
-			const res = await piRouter.fetch("/characters-sync", {
+			const res = await piRouter.fetch("public:/characters-sync", {
 				game: "Mario World"
 			});
 
@@ -75,7 +75,7 @@ describe("route", () => {
 			expect(action.spyOnGetCharactersSync).toHaveBeenLastCalledWith<[MessageRequest<Filter>, MessageResponder]>(
 				{
 					action: new Action(ev),
-					path: "/characters-sync",
+					path: "public:/characters-sync",
 					unidirectional: false,
 					body: {
 						game: "Mario World"
@@ -95,14 +95,14 @@ describe("route", () => {
 		test("void", async () => {
 			// Arrange, act.
 			const action = new ActionWithRoutes();
-			const res = await piRouter.fetch("/save");
+			const res = await piRouter.fetch("public:/save");
 
 			// Assert.
 			expect(action.spyOnSave).toHaveBeenCalledTimes(1);
 			expect(action.spyOnSave).toHaveBeenLastCalledWith<[MessageRequest<Filter>, MessageResponder]>(
 				{
 					action: new Action(ev),
-					path: "/save",
+					path: "public:/save",
 					unidirectional: false,
 					body: undefined
 				},
@@ -124,7 +124,7 @@ describe("route", () => {
 		test("async", async () => {
 			// Arrange, act.
 			const action = new ActionWithRoutes();
-			const res = await piRouter.fetch("/characters", {
+			const res = await piRouter.fetch("public:/characters", {
 				game: "World of Warcraft"
 			});
 
@@ -141,7 +141,7 @@ describe("route", () => {
 		test("sync", async () => {
 			// Arrange, act.
 			const action = new ActionWithRoutes();
-			const res = await piRouter.fetch("/characters-sync", {
+			const res = await piRouter.fetch("public:/characters-sync", {
 				game: "Mario World"
 			});
 
@@ -158,7 +158,7 @@ describe("route", () => {
 		test("void", async () => {
 			// Arrange, act.
 			const action = new ActionWithRoutes();
-			const res = await piRouter.fetch("/save");
+			const res = await piRouter.fetch("public:/save");
 
 			// Assert.
 			expect(action.spyOnSave).toHaveBeenCalledTimes(0);

--- a/src/plugin/ui/__tests__/router.test.ts
+++ b/src/plugin/ui/__tests__/router.test.ts
@@ -85,7 +85,7 @@ describe("current UI", () => {
 		// Assert.
 		expect(spyOnFetch).toBeCalledTimes(1);
 		expect(spyOnFetch).toHaveBeenCalledWith<[MessageRequestOptions]>({
-			path: "/test",
+			path: "public:/test",
 			timeout: 1,
 			unidirectional: true
 		});

--- a/src/plugin/ui/controller.ts
+++ b/src/plugin/ui/controller.ts
@@ -2,7 +2,7 @@ import type streamDeck from "../";
 import type { DidReceivePropertyInspectorMessage, PropertyInspectorDidAppear, PropertyInspectorDidDisappear } from "../../api";
 import type { IDisposable } from "../../common/disposable";
 import type { JsonObject, JsonValue } from "../../common/json";
-import type { RouteConfiguration } from "../../common/messaging";
+import { PUBLIC_PATH_PREFIX, type RouteConfiguration } from "../../common/messaging";
 import { Action } from "../actions/action";
 import { connection } from "../connection";
 import { ActionWithoutPayloadEvent, SendToPluginEvent, type PropertyInspectorDidAppearEvent, type PropertyInspectorDidDisappearEvent } from "../events";
@@ -80,7 +80,7 @@ class UIController {
 		handler: MessageHandler<TBody, TSettings>,
 		options?: RouteConfiguration<Action>
 	): IDisposable {
-		return router.route(path, handler, options);
+		return router.route(`${PUBLIC_PATH_PREFIX}${path}`, handler, options);
 	}
 }
 

--- a/src/plugin/ui/property-inspector.ts
+++ b/src/plugin/ui/property-inspector.ts
@@ -1,7 +1,7 @@
 import type streamDeck from "../";
 import type { ActionIdentifier, DeviceIdentifier } from "../../api";
 import type { JsonValue } from "../../common/json";
-import type { MessageGateway, MessageRequestOptions, MessageResponse } from "../../common/messaging";
+import { PUBLIC_PATH_PREFIX, type MessageGateway, type MessageRequestOptions, type MessageResponse } from "../../common/messaging";
 import type { Action } from "../actions/action";
 import { ActionContext } from "../actions/context";
 import type { SingletonAction } from "../actions/singleton-action";
@@ -71,9 +71,12 @@ export class PropertyInspector extends ActionContext implements Pick<MessageGate
 	 */
 	public async fetch<T extends JsonValue = JsonValue>(requestOrPath: MessageRequestOptions | string, bodyOrUndefined?: JsonValue): Promise<MessageResponse<T>> {
 		if (typeof requestOrPath === "string") {
-			return this.router.fetch(requestOrPath, bodyOrUndefined);
+			return this.router.fetch(`${PUBLIC_PATH_PREFIX}${requestOrPath}`, bodyOrUndefined);
 		} else {
-			return this.router.fetch(requestOrPath);
+			return this.router.fetch({
+				...requestOrPath,
+				path: `${PUBLIC_PATH_PREFIX}${requestOrPath.path}`
+			});
 		}
 	}
 

--- a/src/plugin/ui/route.ts
+++ b/src/plugin/ui/route.ts
@@ -1,5 +1,5 @@
 import type { JsonObject, JsonValue } from "../../common/json";
-import { type MessageResponder } from "../../common/messaging";
+import { PUBLIC_PATH_PREFIX, type MessageResponder } from "../../common/messaging";
 import type { SingletonAction } from "../actions/singleton-action";
 import type { MessageHandler, MessageRequest } from "./message";
 import { router } from "./router";
@@ -14,7 +14,7 @@ export function route<TBody extends JsonValue = JsonValue, TSettings extends Jso
 ): (target: MessageHandler<TBody, TSettings>, context: ClassMethodDecoratorContext<SingletonAction>) => OptionalParameterMessageHandler<TBody, TSettings, TResult> | void {
 	return function (target: MessageHandler<TBody, TSettings>, context: ClassMethodDecoratorContext<SingletonAction>): void {
 		context.addInitializer(function () {
-			router.route(path, target.bind(this), {
+			router.route(`${PUBLIC_PATH_PREFIX}${path}`, target.bind(this), {
 				filter: (source) => source.manifestId === this.manifestId
 			});
 		});

--- a/src/ui/__tests__/plugin.test.ts
+++ b/src/ui/__tests__/plugin.test.ts
@@ -46,7 +46,7 @@ describe("plugin", () => {
 				payload: {
 					__type: "request",
 					id: mockUUID,
-					path: "/outbound/path-and-body",
+					path: "public:/outbound/path-and-body",
 					unidirectional: false,
 					body: {
 						name: "Elgato"
@@ -81,7 +81,7 @@ describe("plugin", () => {
 				payload: {
 					__type: "request",
 					id: mockUUID,
-					path: "/outbound/request",
+					path: "public:/outbound/request",
 					unidirectional: true,
 					body: {
 						name: "Elgato"
@@ -149,7 +149,7 @@ describe("plugin", () => {
 
 		// Assert.
 		expect(spyOnRoute).toHaveBeenCalledTimes(1);
-		expect(spyOnRoute).toHaveBeenCalledWith("/register", handler, options);
+		expect(spyOnRoute).toHaveBeenCalledWith("public:/register", handler, options);
 	});
 
 	/**
@@ -166,7 +166,7 @@ describe("plugin", () => {
 			payload: {
 				__type: "request",
 				id: "abc123",
-				path: "/receive",
+				path: "public:/receive",
 				unidirectional: false,
 				body: {
 					name: "Elgato"
@@ -189,7 +189,7 @@ describe("plugin", () => {
 					getSettings,
 					setSettings
 				},
-				path: "/receive",
+				path: "public:/receive",
 				unidirectional: false,
 				body: {
 					name: "Elgato"

--- a/src/ui/plugin.ts
+++ b/src/ui/plugin.ts
@@ -2,6 +2,7 @@ import type { IDisposable } from "../common/disposable";
 import type { JsonObject, JsonValue } from "../common/json";
 import {
 	MessageGateway,
+	PUBLIC_PATH_PREFIX,
 	type MessageRequestOptions,
 	type MessageResponder,
 	type MessageResponse,
@@ -80,9 +81,12 @@ class PluginController {
 	 */
 	public async fetch<T extends JsonValue = JsonValue>(requestOrPath: MessageRequestOptions | string, bodyOrUndefined?: JsonValue): Promise<MessageResponse<T>> {
 		if (typeof requestOrPath === "string") {
-			return router.fetch(requestOrPath, bodyOrUndefined);
+			return router.fetch(`${PUBLIC_PATH_PREFIX}${requestOrPath}`, bodyOrUndefined);
 		} else {
-			return router.fetch(requestOrPath);
+			return router.fetch({
+				...requestOrPath,
+				path: `${PUBLIC_PATH_PREFIX}${requestOrPath.path}`
+			});
 		}
 	}
 
@@ -130,7 +134,7 @@ class PluginController {
 		handler: MessageHandler<TBody, TSettings>,
 		options?: RouteConfiguration<Action>
 	): IDisposable {
-		return router.route(path, handler, options);
+		return router.route(`${PUBLIC_PATH_PREFIX}${path}`, handler, options);
 	}
 
 	/**


### PR DESCRIPTION
- Update paths of exported routing to be prefixed with `"public:"`, applies to the following:
  - `@route`
  - `streamDeck.ui.current.fetch`
  - `streamDeck.ui.registerRoute`
  - `streamDeck.plugin.fetch`
  - `streamDeck.plugin.registerRoute`