### PR TITLE
fix: race condition tracking current ui

### DIFF
--- a/src/plugin/ui/__tests__/router.test.ts
+++ b/src/plugin/ui/__tests__/router.test.ts
@@ -36,9 +36,39 @@ describe("current UI", () => {
 	});
 
 	/**
-	 * Asserts {@link getCurrentUI} is unset when the connection emits `propertyInspectorDidDisappear`.
+	 * Asserts {@link getCurrentUI} is overwritten when the connection emits `propertyInspectorDidAppear`.
 	 */
-	it("unset on propertyInspectorDidDisappear", () => {
+	it("overwrites on propertyInspectorDidAppear", () => {
+		// Arrange.
+		connection.emit("propertyInspectorDidAppear", {
+			action: "com.elgato.test.one",
+			context: "__first__",
+			device: "dev123",
+			event: "propertyInspectorDidAppear"
+		});
+
+		connection.emit("propertyInspectorDidAppear", {
+			action: "com.elgato.test.one",
+			context: "abc123",
+			device: "dev123",
+			event: "propertyInspectorDidAppear"
+		});
+
+		// Act.
+		const current = getCurrentUI();
+
+		// Assert.
+		expect(current).toBeInstanceOf(PropertyInspector);
+		expect(current).not.toBeUndefined();
+		expect(current?.deviceId).toBe("dev123");
+		expect(current?.id).toBe("abc123");
+		expect(current?.manifestId).toBe("com.elgato.test.one");
+	});
+
+	/**
+	 * Asserts {@link getCurrentUI} is unset when the connection emits `propertyInspectorDidDisappear` for the current UI.
+	 */
+	it("clears matching propertyInspectorDidDisappear", () => {
 		// Arrange.
 		connection.emit("propertyInspectorDidAppear", {
 			action: "com.elgato.test.one",
@@ -60,6 +90,33 @@ describe("current UI", () => {
 
 		// Assert.
 		expect(current).toBeUndefined();
+	});
+
+	/**
+	 * Asserts {@link getCurrentUI} is not cleared the connection emits `propertyInspectorDidDisappear` for a UI that is not the current.
+	 */
+	it("does not clear non-matching propertyInspectorDidDisappear", () => {
+		// Arrange.
+		connection.emit("propertyInspectorDidAppear", {
+			action: "com.elgato.test.one",
+			context: "abc123",
+			device: "dev123",
+			event: "propertyInspectorDidAppear"
+		});
+
+		expect(getCurrentUI()).not.toBeUndefined();
+		connection.emit("propertyInspectorDidDisappear", {
+			action: "com.elgato.test.one",
+			context: "__other__",
+			device: "dev123",
+			event: "propertyInspectorDidDisappear"
+		});
+
+		// Act.
+		const current = getCurrentUI();
+
+		// Assert.
+		expect(current).not.toBeUndefined();
 	});
 
 	/**
@@ -232,10 +289,19 @@ describe("router", () => {
 		 */
 		test("without ui", async () => {
 			// Arrange.
-			connection.emit("propertyInspectorDidDisappear", {
+			const ev = {
 				action: "com.elgato.test.one",
 				context: "proxy-outbound-message-without-ui",
-				device: "dev123",
+				device: "dev123"
+			};
+
+			connection.emit("propertyInspectorDidAppear", {
+				...ev,
+				event: "propertyInspectorDidAppear"
+			});
+
+			connection.emit("propertyInspectorDidDisappear", {
+				...ev,
 				event: "propertyInspectorDidDisappear"
 			});
 

--- a/src/plugin/ui/router.ts
+++ b/src/plugin/ui/router.ts
@@ -60,8 +60,11 @@ connection.on("propertyInspectorDidAppear", (ev) => {
 });
 
 connection.on("propertyInspectorDidDisappear", (ev) => {
-	if (isCurrent(ev) && --debounceCount <= 0) {
-		current = undefined;
+	if (isCurrent(ev)) {
+		debounceCount--;
+		if (debounceCount <= 0) {
+			current = undefined;
+		}
 	}
 });
 

--- a/src/plugin/ui/router.ts
+++ b/src/plugin/ui/router.ts
@@ -1,3 +1,4 @@
+import type { PropertyInspectorDidAppear, PropertyInspectorDidDisappear } from "../../api";
 import type { JsonValue } from "../../common/json";
 import { MessageGateway } from "../../common/messaging";
 import { Action } from "../actions/action";
@@ -5,6 +6,7 @@ import { connection } from "../connection";
 import { PropertyInspector } from "./property-inspector";
 
 let current: PropertyInspector | undefined;
+let debounceCount = 0;
 
 /**
  * Gets the current property inspector.
@@ -35,12 +37,34 @@ const router = new MessageGateway<Action>(
 	(source) => new Action(source)
 );
 
-connection.on("propertyInspectorDidAppear", (ev) => (current = new PropertyInspector(router, ev)));
+/**
+ * Determines whether the specified event is related to the current tracked property inspector.
+ * @param ev The event.
+ * @returns `true` when the event is related to the current property inspector.
+ */
+function isCurrent(ev: PropertyInspectorDidAppear | PropertyInspectorDidDisappear): boolean {
+	return current?.id === ev.context && current.manifestId === ev.action && current.deviceId === ev.device;
+}
+
+/*
+ * To overcome event races, the debounce counter keeps track of appear vs disappear events, ensuring we only
+ * clear the current ui when an equal number of matching disappear events occur.
+ */
+connection.on("propertyInspectorDidAppear", (ev) => {
+	if (isCurrent(ev)) {
+		debounceCount++;
+	} else {
+		debounceCount = 1;
+		current = new PropertyInspector(router, ev);
+	}
+});
+
 connection.on("propertyInspectorDidDisappear", (ev) => {
-	if (current?.id === ev.context && current.manifestId === ev.action && current.deviceId === ev.device) {
+	if (isCurrent(ev) && --debounceCount <= 0) {
 		current = undefined;
 	}
 });
+
 connection.on("sendToPlugin", (ev) => router.process(ev));
 
 export { router };

--- a/src/plugin/ui/router.ts
+++ b/src/plugin/ui/router.ts
@@ -36,7 +36,11 @@ const router = new MessageGateway<Action>(
 );
 
 connection.on("propertyInspectorDidAppear", (ev) => (current = new PropertyInspector(router, ev)));
-connection.on("propertyInspectorDidDisappear", () => (current = undefined));
+connection.on("propertyInspectorDidDisappear", (ev) => {
+	if (current?.id === ev.context && current.manifestId === ev.action && current.deviceId === ev.device) {
+		current = undefined;
+	}
+});
 connection.on("sendToPlugin", (ev) => router.process(ev));
 
 export { router };


### PR DESCRIPTION
This PR addresses a race condition, when tracking the current UI, that can occur when open/closing the property inspector in quick succession, causing the `propertyInspectorDidAppear` and `propertyInspectorDidDisappear` to run out of sync.