### PR TITLE
feat: wrap existing connectElgatoStreamDeckSocket

### DIFF
--- a/src/ui/__tests__/connection.test.ts
+++ b/src/ui/__tests__/connection.test.ts
@@ -148,6 +148,36 @@ describe("connection", () => {
 			}
 		});
 	});
+
+	/**
+	 * Asserts the connection wraps an existing `connectElgatoStreamDeckSocket` if it is defined on the window.
+	 */
+	it("wraps connectElgatoStreamDeckSocket", async () => {
+		// Arrange.
+		jest.resetModules();
+
+		const event = "register";
+		const uuid = "123_registers";
+
+		// Act.
+		const existingFn = jest.fn();
+		window.connectElgatoStreamDeckSocket = existingFn;
+		const { connection } = await require("../connection");
+
+		await window.connectElgatoStreamDeckSocket(port, uuid, event, JSON.stringify(registrationInfo), JSON.stringify(actionInfo));
+
+		// Assert.
+		expect(existingFn).toHaveBeenCalledTimes(1);
+		expect(existingFn).toHaveBeenLastCalledWith<Parameters<typeof window.connectElgatoStreamDeckSocket>>(
+			port,
+			uuid,
+			event,
+			JSON.stringify(registrationInfo),
+			JSON.stringify(actionInfo)
+		);
+
+		await expect(server).toReceiveMessage({ event, uuid });
+	});
 });
 
 type Settings = {

--- a/src/ui/connection.ts
+++ b/src/ui/connection.ts
@@ -43,8 +43,8 @@ class Connection extends EventEmitter<ExtendedUIEventMap> {
 
 		window.connectElgatoStreamDeckSocket = ((fn = () => {}) => {
 			return async (port: string, uuid: string, event: string, info: string, actionInfo: string): Promise<void> => {
-				fn(port, uuid, event, info, actionInfo);
 				await this.connect(port, uuid, event, JSON.parse(info), JSON.parse(actionInfo));
+				fn(port, uuid, event, info, actionInfo);
 			};
 		})(window.connectElgatoStreamDeckSocket);
 	}

--- a/src/ui/connection.ts
+++ b/src/ui/connection.ts
@@ -43,8 +43,8 @@ class Connection extends EventEmitter<ExtendedUIEventMap> {
 
 		window.connectElgatoStreamDeckSocket = ((fn = () => {}) => {
 			return async (port: string, uuid: string, event: string, info: string, actionInfo: string): Promise<void> => {
-				await this.connect(port, uuid, event, JSON.parse(info), JSON.parse(actionInfo));
 				fn(port, uuid, event, info, actionInfo);
+				await this.connect(port, uuid, event, JSON.parse(info), JSON.parse(actionInfo));
 			};
 		})(window.connectElgatoStreamDeckSocket);
 	}

--- a/src/ui/connection.ts
+++ b/src/ui/connection.ts
@@ -41,9 +41,12 @@ class Connection extends EventEmitter<ExtendedUIEventMap> {
 	constructor() {
 		super();
 
-		window.connectElgatoStreamDeckSocket = (port: string, uuid: string, event: string, info: string, actionInfo: string): Promise<void> => {
-			return this.connect(port, uuid, event, JSON.parse(info), JSON.parse(actionInfo));
-		};
+		window.connectElgatoStreamDeckSocket = ((fn = () => {}) => {
+			return async (port: string, uuid: string, event: string, info: string, actionInfo: string): Promise<void> => {
+				await this.connect(port, uuid, event, JSON.parse(info), JSON.parse(actionInfo));
+				fn(port, uuid, event, info, actionInfo);
+			};
+		})(window.connectElgatoStreamDeckSocket);
 	}
 
 	/**


### PR DESCRIPTION
This PR updates the UI connection to wrap an existing `window.connectElgatoStreamDeckSocket` function if it exists.