### PR TITLE
feat: iterator helpers

### DIFF
--- a/src/common/__tests__/enumerable.test.ts
+++ b/src/common/__tests__/enumerable.test.ts
@@ -249,6 +249,69 @@ describe("Enumerable", () => {
 	});
 
 	/**
+	 * Provides assertions for {@link Enumerable.drop}.
+	 */
+	describe("drop", () => {
+		it("accepts limit 0", () => {
+			// Arrange, act, assert
+			expect(enumerable.drop(0).length).toBe(source.length);
+		});
+
+		it("accepts limit 1", () => {
+			// Arrange.
+			const fn = jest.fn();
+
+			// Act.
+			const res = enumerable.drop(1);
+			res.forEach(fn);
+
+			// Assert.
+			expect(res.length).toBe(2);
+			expect(fn).toHaveBeenCalledTimes(2);
+			expect(fn).toHaveBeenNthCalledWith(1, { name: "Stream Deck" });
+			expect(fn).toHaveBeenNthCalledWith(2, { name: "Wave DX" });
+		});
+
+		it("accepts limit less than length", () => {
+			// Arrange.
+			const fn = jest.fn();
+
+			// Act.
+			const res = enumerable.drop(2);
+			res.forEach(fn);
+
+			// Assert.
+			expect(res.length).toBe(1);
+			expect(fn).toHaveBeenCalledTimes(1);
+			expect(fn).toHaveBeenCalledWith({ name: "Wave DX" });
+		});
+
+		it("accepts limit exceeding length", () => {
+			// Arrange.
+			const fn = jest.fn();
+
+			// Act.
+			const res = enumerable.drop(4);
+			res.forEach(fn);
+
+			// Assert.
+			expect(res.length).toBe(0);
+			expect(fn).toHaveBeenCalledTimes(0);
+		});
+
+		it("throw for negative", () => {
+			// Arrange, act, assert
+			expect(() => enumerable.drop(-1)).toThrow(RangeError);
+		});
+
+		it("throw for NaN", () => {
+			// Arrange, act, assert
+			// @ts-expect-error Test non-number
+			expect(() => enumerable.drop("false")).toThrow(RangeError);
+		});
+	});
+
+	/**
 	 * Provides assertions for {@link Enumerable.every}.
 	 */
 	describe("every", () => {

--- a/src/common/__tests__/enumerable.test.ts
+++ b/src/common/__tests__/enumerable.test.ts
@@ -469,6 +469,21 @@ describe("Enumerable", () => {
 		});
 	});
 
+	test("flatMap", () => {
+		// Arrange, act.
+		const fn = jest.fn();
+		const res = enumerable.flatMap((x) => x.name.split(" ").values());
+
+		// Assert.
+		res.forEach(fn);
+		expect(fn).toHaveBeenCalledTimes(5);
+		expect(fn).toHaveBeenNthCalledWith(1, "Facecam");
+		expect(fn).toHaveBeenNthCalledWith(2, "Stream");
+		expect(fn).toHaveBeenNthCalledWith(3, "Deck");
+		expect(fn).toHaveBeenNthCalledWith(4, "Wave");
+		expect(fn).toHaveBeenNthCalledWith(5, "DX");
+	});
+
 	/**
 	 * Provides assertions for {@link Enumerable.forEach}.
 	 */

--- a/src/common/__tests__/enumerable.test.ts
+++ b/src/common/__tests__/enumerable.test.ts
@@ -249,6 +249,22 @@ describe("Enumerable", () => {
 	});
 
 	/**
+	 * Asserts the iterator of an {@link asIndexedPairs}.
+	 */
+	test.only("asIndexedPairs", () => {
+		// Arrange, act.
+		const fn = jest.fn();
+		const res = enumerable.asIndexedPairs();
+
+		// Assert.
+		res.forEach(fn);
+		expect(fn).toHaveBeenCalledTimes(3);
+		expect(fn).toHaveBeenNthCalledWith(1, [0, { name: "Facecam" }]);
+		expect(fn).toHaveBeenNthCalledWith(2, [1, { name: "Stream Deck" }]);
+		expect(fn).toHaveBeenNthCalledWith(3, [2, { name: "Wave DX" }]);
+	});
+
+	/**
 	 * Provides assertions for {@link Enumerable.drop}.
 	 */
 	describe("drop", () => {
@@ -263,9 +279,9 @@ describe("Enumerable", () => {
 
 			// Act.
 			const res = enumerable.drop(1);
-			res.forEach(fn);
 
 			// Assert.
+			res.forEach(fn);
 			expect(res.length).toBe(2);
 			expect(fn).toHaveBeenCalledTimes(2);
 			expect(fn).toHaveBeenNthCalledWith(1, { name: "Stream Deck" });
@@ -278,9 +294,9 @@ describe("Enumerable", () => {
 
 			// Act.
 			const res = enumerable.drop(2);
-			res.forEach(fn);
 
 			// Assert.
+			res.forEach(fn);
 			expect(res.length).toBe(1);
 			expect(fn).toHaveBeenCalledTimes(1);
 			expect(fn).toHaveBeenCalledWith({ name: "Wave DX" });
@@ -292,9 +308,9 @@ describe("Enumerable", () => {
 
 			// Act.
 			const res = enumerable.drop(4);
-			res.forEach(fn);
 
 			// Assert.
+			res.forEach(fn);
 			expect(res.length).toBe(0);
 			expect(fn).toHaveBeenCalledTimes(0);
 		});

--- a/src/common/__tests__/enumerable.test.ts
+++ b/src/common/__tests__/enumerable.test.ts
@@ -360,7 +360,7 @@ describe("Enumerable", () => {
 	});
 
 	/**
-	 * Asserts the iterator of an {@link asIndexedPairs}.
+	 * Asserts the iterator of an {@link Enumerable.asIndexedPairs}.
 	 */
 	test("asIndexedPairs", () => {
 		// Arrange, act.

--- a/src/common/__tests__/enumerable.test.ts
+++ b/src/common/__tests__/enumerable.test.ts
@@ -195,6 +195,40 @@ describe("Enumerable", () => {
 				expect(enumerable.length).toBe(3);
 			});
 		});
+
+		/**
+		 * With IterableIterator<T> delegate.
+		 */
+		describe("IterableIterator", () => {
+			it("iterates mutated map", () => {
+				// Arrange.
+				const fn = jest.fn();
+				const itr = function* () {
+					yield "One";
+					yield "Two";
+				};
+				const enumerable = new Enumerable(itr);
+
+				// Act, assert.
+				enumerable.forEach(fn);
+				expect(enumerable.length).toBe(2);
+				expect(fn).toHaveBeenCalledTimes(2);
+				expect(fn).toHaveBeenNthCalledWith(1, "One");
+				expect(fn).toHaveBeenNthCalledWith(2, "Two");
+			});
+
+			it("reads length", () => {
+				// Arrange.
+				const itr = function* () {
+					yield "One";
+					yield "Two";
+				};
+
+				// Act, assert.
+				const enumerable = new Enumerable(itr);
+				expect(enumerable.length).toBe(2);
+			});
+		});
 	});
 
 	/**

--- a/src/common/__tests__/enumerable.test.ts
+++ b/src/common/__tests__/enumerable.test.ts
@@ -232,6 +232,69 @@ describe("Enumerable", () => {
 	});
 
 	/**
+	 * Asserts {@link Enumerable} implements {@link IterableIterator}.
+	 */
+	describe("IterableIterator implementation", () => {
+		describe("next", () => {
+			it("iterates all items", () => {
+				// Arrange.
+				const enumerable = new Enumerable(["One", "Two", "Three"]);
+
+				// Act, assert.
+				expect(enumerable.next()).toStrictEqual({ done: false, value: "One" });
+				expect(enumerable.next()).toStrictEqual({ done: false, value: "Two" });
+				expect(enumerable.next()).toStrictEqual({ done: false, value: "Three" });
+				expect(enumerable.next()).toStrictEqual({ done: true, value: undefined });
+			});
+
+			it("re-captures on return", () => {
+				// Arrange.
+				const enumerable = new Enumerable(["One", "Two", "Three"]);
+
+				// Act, assert (1).
+				expect(enumerable.next()).toStrictEqual({ done: false, value: "One" });
+				expect(enumerable.return?.("Stop")).toStrictEqual({ done: true, value: "Stop" });
+
+				// Act, assert (2).
+				expect(enumerable.next()).toStrictEqual({ done: false, value: "One" });
+				expect(enumerable.next()).toStrictEqual({ done: false, value: "Two" });
+				expect(enumerable.next()).toStrictEqual({ done: false, value: "Three" });
+				expect(enumerable.next()).toStrictEqual({ done: true, value: undefined });
+			});
+
+			it("does not re-capture on throw", () => {
+				// Arrange.
+				const enumerable = new Enumerable(["One", "Two", "Three"]);
+
+				// Act, assert..
+				expect(enumerable.next()).toStrictEqual({ done: false, value: "One" });
+				expect(() => enumerable.throw?.("Staged error")).toThrow("Staged error");
+				expect(enumerable.next()).toStrictEqual({ done: false, value: "Two" });
+				expect(enumerable.next()).toStrictEqual({ done: false, value: "Three" });
+				expect(enumerable.next()).toStrictEqual({ done: true, value: undefined });
+			});
+		});
+
+		test("return", () => {
+			// Arrange.
+			const enumerable = new Enumerable([1, 2, 3]);
+
+			// Act, assert.
+			const res = enumerable.return?.("Hello world");
+			expect(res?.done).toBe(true);
+			expect(res?.value).toBe("Hello world");
+		});
+
+		test("throw", () => {
+			// Arrange.
+			const enumerable = new Enumerable([1, 2, 3]);
+
+			// Act, assert.
+			expect(() => enumerable.throw?.("Hello world")).toThrow("Hello world");
+		});
+	});
+
+	/**
 	 * Asserts chaining for methods of {@link Enumerable} that support it.
 	 */
 	describe("iterator helpers", () => {

--- a/src/common/__tests__/enumerable.test.ts
+++ b/src/common/__tests__/enumerable.test.ts
@@ -251,7 +251,7 @@ describe("Enumerable", () => {
 	/**
 	 * Asserts the iterator of an {@link asIndexedPairs}.
 	 */
-	test.only("asIndexedPairs", () => {
+	test("asIndexedPairs", () => {
 		// Arrange, act.
 		const fn = jest.fn();
 		const res = enumerable.asIndexedPairs();
@@ -282,7 +282,6 @@ describe("Enumerable", () => {
 
 			// Assert.
 			res.forEach(fn);
-			expect(res.length).toBe(2);
 			expect(fn).toHaveBeenCalledTimes(2);
 			expect(fn).toHaveBeenNthCalledWith(1, { name: "Stream Deck" });
 			expect(fn).toHaveBeenNthCalledWith(2, { name: "Wave DX" });
@@ -297,7 +296,6 @@ describe("Enumerable", () => {
 
 			// Assert.
 			res.forEach(fn);
-			expect(res.length).toBe(1);
 			expect(fn).toHaveBeenCalledTimes(1);
 			expect(fn).toHaveBeenCalledWith({ name: "Wave DX" });
 		});
@@ -311,7 +309,6 @@ describe("Enumerable", () => {
 
 			// Assert.
 			res.forEach(fn);
-			expect(res.length).toBe(0);
 			expect(fn).toHaveBeenCalledTimes(0);
 		});
 
@@ -594,6 +591,69 @@ describe("Enumerable", () => {
 			expect(fn).toHaveBeenCalledWith({ name: "Facecam" });
 			expect(fn).toHaveBeenCalledWith({ name: "Stream Deck" });
 			expect(fn).toHaveBeenCalledWith({ name: "Wave DX" });
+		});
+	});
+
+	/**
+	 * Provides assertions for {@link Enumerable.take}.
+	 */
+	describe("take", () => {
+		it("accepts limit 0", () => {
+			// Arrange, act, assert
+			expect(enumerable.take(0).length).toBe(0);
+		});
+
+		it("accepts limit 1", () => {
+			// Arrange.
+			const fn = jest.fn();
+
+			// Act.
+			const res = enumerable.take(1);
+
+			// Assert.
+			res.forEach(fn);
+			expect(fn).toHaveBeenCalledTimes(1);
+			expect(fn).toHaveBeenNthCalledWith(1, { name: "Facecam" });
+		});
+
+		it("accepts limit less than length", () => {
+			// Arrange.
+			const fn = jest.fn();
+
+			// Act.
+			const res = enumerable.take(2);
+
+			// Assert.
+			res.forEach(fn);
+			expect(fn).toHaveBeenCalledTimes(2);
+			expect(fn).toHaveBeenNthCalledWith(1, { name: "Facecam" });
+			expect(fn).toHaveBeenNthCalledWith(2, { name: "Stream Deck" });
+		});
+
+		it("accepts limit exceeding length", () => {
+			// Arrange.
+			const fn = jest.fn();
+
+			// Act.
+			const res = enumerable.take(99);
+
+			// Assert.
+			res.forEach(fn);
+			expect(fn).toHaveBeenCalledTimes(3);
+			expect(fn).toHaveBeenNthCalledWith(1, { name: "Facecam" });
+			expect(fn).toHaveBeenNthCalledWith(2, { name: "Stream Deck" });
+			expect(fn).toHaveBeenNthCalledWith(3, { name: "Wave DX" });
+		});
+
+		it("throw for negative", () => {
+			// Arrange, act, assert
+			expect(() => enumerable.take(-1)).toThrow(RangeError);
+		});
+
+		it("throw for NaN", () => {
+			// Arrange, act, assert
+			// @ts-expect-error Test non-number
+			expect(() => enumerable.take("false")).toThrow(RangeError);
 		});
 	});
 });

--- a/src/common/__tests__/enumerable.test.ts
+++ b/src/common/__tests__/enumerable.test.ts
@@ -656,4 +656,33 @@ describe("Enumerable", () => {
 			expect(() => enumerable.take("false")).toThrow(RangeError);
 		});
 	});
+
+	/**
+	 * Provides assertions for {@link Enumerable.toArray}.
+	 */
+	describe("toArray", () => {
+		it("returns a new array of items", () => {
+			// Arrange.
+			const arr = ["One", "Two"];
+			const enumerable = new Enumerable(arr);
+
+			// Act.
+			const res = enumerable.toArray();
+
+			// Assert.
+			expect(arr).toEqual(res);
+			expect(arr).not.toBe(res);
+		});
+
+		it("can return an empty array", () => {
+			// Arrange.
+			const enumerable = new Enumerable(function* () {});
+
+			// Act.
+			const res = enumerable.toArray();
+
+			// Assert
+			expect(res).toHaveLength(0);
+		});
+	});
 });

--- a/src/common/__tests__/enumerable.test.ts
+++ b/src/common/__tests__/enumerable.test.ts
@@ -232,6 +232,54 @@ describe("Enumerable", () => {
 	});
 
 	/**
+	 * Asserts chaining for methods of {@link Enumerable} that support it.
+	 */
+	describe("iterator helpers", () => {
+		it("chains iterators", () => {
+			// Arrange.
+			const fn = jest.fn();
+			const source = ["One", "Two", "Three"];
+			const enumerable = new Enumerable(source);
+
+			// Act.
+			enumerable
+				.asIndexedPairs() // [0, "One"], [1, "Two"], [2, "Three"]
+				.drop(1) // [1, "Two"], [2, "Three"]
+				.flatMap(([i, value]) => [i, value].values()) // 1, "Two", 2, "Three"
+				.filter((x) => typeof x === "number") // 1, 2
+				.map((x) => {
+					return { value: x };
+				}) // { value: 1 }, { value: 2 }
+				.take(1) // { value: 1 }
+				.forEach(fn);
+
+			// Assert.
+			expect(fn).toHaveBeenCalledTimes(1);
+			expect(fn).toHaveBeenNthCalledWith(1, { value: 1 });
+		});
+
+		it("should not iterate unless necessary", () => {
+			// Arrange.
+			const fn = jest.fn();
+			const enumerable = new Enumerable(fn);
+
+			// Act.
+			enumerable
+				.asIndexedPairs()
+				.drop(1)
+				.flatMap(([i, value]) => [i, value].values())
+				.filter((x) => typeof x === "number")
+				.map((x) => {
+					return { value: x };
+				})
+				.take(1);
+
+			// Assert.
+			expect(fn).toHaveBeenCalledTimes(0);
+		});
+	});
+
+	/**
 	 * Asserts the iterator of an {@link Enumerable}.
 	 */
 	describe("iterator", () => {

--- a/src/common/enumerable.ts
+++ b/src/common/enumerable.ts
@@ -63,6 +63,28 @@ export class Enumerable<T> implements IterableIterator<T> {
 	}
 
 	/**
+	 * Produces a new iterator with the first items dropped, up to the specified limit.
+	 * @param limit The number of elements to drop from the start of the iteration.
+	 * @returns An iterator of items after the limit.
+	 */
+	public drop(limit: number): Enumerable<T> {
+		if (isNaN(limit) || limit < 0) {
+			throw new RangeError("limit must be a number greater than 0");
+		}
+
+		return new Enumerable(
+			function* (this: Enumerable<T>) {
+				let i = 0;
+				for (const foo of this.#items()) {
+					if (i++ >= limit) {
+						yield foo;
+					}
+				}
+			}.bind(this)
+		);
+	}
+
+	/**
 	 * Determines whether all items satisfy the specified predicate.
 	 * @param predicate Function that determines whether each item fulfils the predicate.
 	 * @returns `true` when all items satisfy the predicate; otherwise `false`.

--- a/src/common/enumerable.ts
+++ b/src/common/enumerable.ts
@@ -297,6 +297,6 @@ export class Enumerable<T> implements IterableIterator<T> {
 	 * @returns The array of items from this iterator.
 	 */
 	public toArray(): T[] {
-		throw new Error("Not implemented");
+		return Array.from(this);
 	}
 }

--- a/src/common/enumerable.ts
+++ b/src/common/enumerable.ts
@@ -38,8 +38,9 @@ export class Enumerable<T> implements IterableIterator<T> {
 		} else {
 			// IterableIterator delegate
 			this.#items = source;
-			this.#length = () => {
+			this.#length = (): number => {
 				let i = 0;
+				// eslint-disable-next-line @typescript-eslint/no-unused-vars
 				for (const _ of this) {
 					i++;
 				}
@@ -69,11 +70,11 @@ export class Enumerable<T> implements IterableIterator<T> {
 
 	/**
 	 * Transforms each item within this iterator to an indexed pair, with each pair represented as an array.
-	 * @returns An iterator with each indexed pair.
+	 * @returns An iterator of indexed pairs.
 	 */
 	public asIndexedPairs(): Enumerable<[number, T]> {
 		return new Enumerable(
-			function* (this: Enumerable<T>) {
+			function* (this: Enumerable<T>): IterableIterator<[number, T]> {
 				let i = 0;
 				for (const item of this) {
 					yield [i++, item] as [number, T];
@@ -83,7 +84,7 @@ export class Enumerable<T> implements IterableIterator<T> {
 	}
 
 	/**
-	 * Produces a new iterator with the first items dropped, up to the specified limit.
+	 * Returns an iterator with the first items dropped, up to the specified limit.
 	 * @param limit The number of elements to drop from the start of the iteration.
 	 * @returns An iterator of items after the limit.
 	 */
@@ -93,7 +94,7 @@ export class Enumerable<T> implements IterableIterator<T> {
 		}
 
 		return new Enumerable(
-			function* (this: Enumerable<T>) {
+			function* (this: Enumerable<T>): IterableIterator<T> {
 				let i = 0;
 				for (const item of this) {
 					if (i++ >= limit) {
@@ -120,13 +121,13 @@ export class Enumerable<T> implements IterableIterator<T> {
 	}
 
 	/**
-	 * Returns an iterable of items that meet the specified condition.
+	 * Returns an iterator of items that meet the specified predicate..
 	 * @param predicate Function that determines which items to filter.
-	 * @yields The filtered items; items that returned `true` when invoked against the predicate.
+	 * @returns An iterator of filtered items.
 	 */
 	public filter(predicate: (value: T) => boolean): Enumerable<T> {
 		return new Enumerable(
-			function* (this: Enumerable<T>) {
+			function* (this: Enumerable<T>): IterableIterator<T> {
 				for (const item of this) {
 					if (predicate(item)) {
 						yield item;
@@ -166,13 +167,13 @@ export class Enumerable<T> implements IterableIterator<T> {
 	}
 
 	/**
-	 * Yields value of each transformed item within this iterator, by calling the specified mapper function.
+	 * Returns an iterator containing items transformed using the specified mapper function.
 	 * @param mapper Function responsible for transforming each item.
-	 * @returns An iterator of the transformed items.
+	 * @returns An iterator of transformed items.
 	 */
 	public flatMap<U>(mapper: (item: T) => IterableIterator<U>): Enumerable<U> {
 		return new Enumerable(
-			function* (this: Enumerable<T>) {
+			function* (this: Enumerable<T>): IterableIterator<U> {
 				for (const item of this) {
 					for (const mapped of mapper(item)) {
 						yield mapped;
@@ -202,13 +203,13 @@ export class Enumerable<T> implements IterableIterator<T> {
 	}
 
 	/**
-	 * Maps each item within the collection to a new structure using the specified mapping function.
+	 * Returns an iterator of mapped items using the mapper function.
 	 * @param mapper Function responsible for mapping the items.
-	 * @yields The mapped items.
+	 * @returns An iterator of mapped items.
 	 */
 	public map<U>(mapper: (value: T) => U): Enumerable<U> {
 		return new Enumerable<U>(
-			function* (this: Enumerable<T>) {
+			function* (this: Enumerable<T>): IterableIterator<U> {
 				for (const item of this) {
 					yield mapper(item);
 				}
@@ -302,7 +303,7 @@ export class Enumerable<T> implements IterableIterator<T> {
 	}
 
 	/**
-	 * Produces a new iterator with the items, from 0, up to the specified limit.
+	 * Returns an iterator with the items, from 0, up to the specified limit.
 	 * @param limit Limit of items to take.
 	 * @returns An iterator of items from 0 to the limit.
 	 */
@@ -312,7 +313,7 @@ export class Enumerable<T> implements IterableIterator<T> {
 		}
 
 		return new Enumerable(
-			function* (this: Enumerable<T>) {
+			function* (this: Enumerable<T>): IterableIterator<T> {
 				let i = 0;
 				for (const item of this) {
 					if (i++ < limit) {
@@ -326,7 +327,6 @@ export class Enumerable<T> implements IterableIterator<T> {
 	/**
 	 * Acts as if a `throw` statement is inserted in the generator's body at the current suspended position.
 	 * @param e Error to throw.
-	 * @returns The current iterator result.
 	 */
 	public throw?<TReturn>(e?: TReturn): IteratorResult<T, TReturn | undefined> {
 		throw e;

--- a/src/common/enumerable.ts
+++ b/src/common/enumerable.ts
@@ -161,6 +161,23 @@ export class Enumerable<T> implements IterableIterator<T> {
 	}
 
 	/**
+	 * Yields value of each transformed item within this iterator, by calling the specified mapper function.
+	 * @param mapper Function responsible for transforming each item.
+	 * @returns An iterator of the transformed items.
+	 */
+	public flatMap<U>(mapper: (item: T) => IterableIterator<U>): Enumerable<U> {
+		return new Enumerable(
+			function* (this: Enumerable<T>) {
+				for (const item of this) {
+					for (const mapped of mapper(item)) {
+						yield mapped;
+					}
+				}
+			}.bind(this)
+		);
+	}
+
+	/**
 	 * Iterates over each item, and invokes the specified function.
 	 * @param fn Function to invoke against each item.
 	 */

--- a/src/common/enumerable.ts
+++ b/src/common/enumerable.ts
@@ -84,7 +84,7 @@ export class Enumerable<T> implements IterableIterator<T> {
 	 */
 	public drop(limit: number): Enumerable<T> {
 		if (isNaN(limit) || limit < 0) {
-			throw new RangeError("limit must be a number greater than 0");
+			throw new RangeError("limit must be 0, or a positive number");
 		}
 
 		return new Enumerable(
@@ -261,6 +261,28 @@ export class Enumerable<T> implements IterableIterator<T> {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Produces a new iterator with the items, from 0, up to the specified limit.
+	 * @param limit Limit of items to take.
+	 * @returns An iterator of items from 0 to the limit.
+	 */
+	public take(limit: number): Enumerable<T> {
+		if (isNaN(limit) || limit < 0) {
+			throw new RangeError("limit must be 0, or a positive number");
+		}
+
+		return new Enumerable(
+			function* (this: Enumerable<T>) {
+				let i = 0;
+				for (const item of this) {
+					if (i++ < limit) {
+						yield item;
+					}
+				}
+			}.bind(this)
+		);
 	}
 
 	/**

--- a/src/common/enumerable.ts
+++ b/src/common/enumerable.ts
@@ -1,7 +1,7 @@
 /**
  * Provides a read-only iterable collection of items that also acts as a partial polyfill for iterator helpers.
  */
-export class Enumerable<T> implements IterableIterator<T> {
+export class Enumerable<T> implements Iterable<T> {
 	/**
 	 * Backing function responsible for providing the iterator of items.
 	 */
@@ -90,9 +90,9 @@ export class Enumerable<T> implements IterableIterator<T> {
 		return new Enumerable(
 			function* (this: Enumerable<T>) {
 				let i = 0;
-				for (const foo of this.#items()) {
+				for (const item of this) {
 					if (i++ >= limit) {
-						yield foo;
+						yield item;
 					}
 				}
 			}.bind(this)
@@ -105,7 +105,7 @@ export class Enumerable<T> implements IterableIterator<T> {
 	 * @returns `true` when all items satisfy the predicate; otherwise `false`.
 	 */
 	public every(predicate: (value: T) => boolean): boolean {
-		for (const item of this.#items()) {
+		for (const item of this) {
 			if (!predicate(item)) {
 				return false;
 			}
@@ -122,7 +122,7 @@ export class Enumerable<T> implements IterableIterator<T> {
 	public filter(predicate: (value: T) => boolean): Enumerable<T> {
 		return new Enumerable(
 			function* (this: Enumerable<T>) {
-				for (const item of this.#items()) {
+				for (const item of this) {
 					if (predicate(item)) {
 						yield item;
 					}
@@ -137,7 +137,7 @@ export class Enumerable<T> implements IterableIterator<T> {
 	 * @returns The first item that satisfied the predicate; otherwise `undefined`.
 	 */
 	public find(predicate: (value: T) => boolean): T | undefined {
-		for (const item of this.#items()) {
+		for (const item of this) {
 			if (predicate(item)) {
 				return item;
 			}
@@ -151,7 +151,7 @@ export class Enumerable<T> implements IterableIterator<T> {
 	 */
 	public findLast(predicate: (value: T) => boolean): T | undefined {
 		let result = undefined;
-		for (const item of this.#items()) {
+		for (const item of this) {
 			if (predicate(item)) {
 				result = item;
 			}
@@ -182,7 +182,7 @@ export class Enumerable<T> implements IterableIterator<T> {
 	 * @param fn Function to invoke against each item.
 	 */
 	public forEach(fn: (item: T) => void): void {
-		for (const item of this.#items()) {
+		for (const item of this) {
 			fn(item);
 		}
 	}
@@ -204,18 +204,11 @@ export class Enumerable<T> implements IterableIterator<T> {
 	public map<U>(mapper: (value: T) => U): Enumerable<U> {
 		return new Enumerable<U>(
 			function* (this: Enumerable<T>) {
-				for (const item of this.#items()) {
+				for (const item of this) {
 					yield mapper(item);
 				}
 			}.bind(this)
 		);
-	}
-
-	/**
-	 * @inheritdoc
-	 */
-	public next(...args: [] | [undefined]): IteratorResult<T, any> {
-		return this.#items().next(...args);
 	}
 
 	/**
@@ -247,7 +240,7 @@ export class Enumerable<T> implements IterableIterator<T> {
 		}
 
 		let result = initial;
-		for (const item of this.#items()) {
+		for (const item of this) {
 			if (result === undefined) {
 				result = item;
 			} else {
@@ -259,19 +252,12 @@ export class Enumerable<T> implements IterableIterator<T> {
 	}
 
 	/**
-	 * @inheritdoc
-	 */
-	public return?<TReturn>(value?: TReturn): IteratorResult<T, TReturn | undefined> {
-		return { value, done: true };
-	}
-
-	/**
 	 * Determines whether an item in the collection exists that satisfies the specified predicate.
 	 * @param predicate Function used to search for an item.
 	 * @returns `true` when the item was found; otherwise `false`.
 	 */
 	public some(predicate: (value: T) => boolean): boolean {
-		for (const item of this.#items()) {
+		for (const item of this) {
 			if (predicate(item)) {
 				return true;
 			}
@@ -300,13 +286,6 @@ export class Enumerable<T> implements IterableIterator<T> {
 				}
 			}.bind(this)
 		);
-	}
-
-	/**
-	 * @inheritdoc
-	 */
-	public throw?<TReturn>(e?: TReturn): never {
-		throw e;
 	}
 
 	/**

--- a/src/common/enumerable.ts
+++ b/src/common/enumerable.ts
@@ -31,9 +31,16 @@ export class Enumerable<T> implements IterableIterator<T> {
 			this.#items = (): IterableIterator<T> => source.values();
 			this.#length = (): number => source.size;
 		} else {
-			// IterableIterator
+			// IterableIterator delegate
 			this.#items = source;
-			this.#length = () => this.reduce((count) => count++, 0);
+			this.#length = () => {
+				let i = 0;
+				for (const _ of this) {
+					i++;
+				}
+
+				return i;
+			};
 		}
 	}
 

--- a/src/common/enumerable.ts
+++ b/src/common/enumerable.ts
@@ -63,6 +63,21 @@ export class Enumerable<T> implements IterableIterator<T> {
 	}
 
 	/**
+	 * Transforms each item within this iterator to an indexed pair, with each pair represented as an array.
+	 * @returns An iterator with each indexed pair.
+	 */
+	public asIndexedPairs(): Enumerable<[number, T]> {
+		return new Enumerable(
+			function* (this: Enumerable<T>) {
+				let i = 0;
+				for (const item of this) {
+					yield [i++, item] as [number, T];
+				}
+			}.bind(this)
+		);
+	}
+
+	/**
 	 * Produces a new iterator with the first items dropped, up to the specified limit.
 	 * @param limit The number of elements to drop from the start of the iteration.
 	 * @returns An iterator of items after the limit.

--- a/src/plugin/actions/singleton-action.ts
+++ b/src/plugin/actions/singleton-action.ts
@@ -1,4 +1,5 @@
 import type streamDeck from "../";
+import type { Enumerable } from "../../common/enumerable";
 import type { JsonObject, JsonValue } from "../../common/json";
 import type { DialAction } from "../actions/dial";
 import type { KeyAction } from "../actions/key";
@@ -34,7 +35,7 @@ export class SingletonAction<T extends JsonObject = JsonObject> {
 	 * Gets the visible actions with the `manifestId` that match this instance's.
 	 * @returns The visible actions.
 	 */
-	public get actions(): IterableIterator<DialAction<T> | KeyAction<T>> {
+	public get actions(): Enumerable<DialAction<T> | KeyAction<T>> {
 		return actionStore.filter((a) => a.manifestId === this.manifestId);
 	}
 


### PR DESCRIPTION
- Adds the [`.drop(limit)`](https://github.com/tc39/proposal-iterator-helpers?tab=readme-ov-file#droplimit), [`.flapMap(mapperFn)`](https://github.com/tc39/proposal-iterator-helpers?tab=readme-ov-file#flatmapmapperfn), [`.take(limit)`](https://github.com/tc39/proposal-iterator-helpers?tab=readme-ov-file#takelimit), and [`.toArray()`](https://github.com/tc39/proposal-iterator-helpers?tab=readme-ov-file#toarray) iterator helpers.
- Updates `filter` and `map` to chain an `Enumerable`.
- Updates `SingletonAction.actions` to return an `Enumerable`
