### PR TITLE
fix: event arg types

### DIFF
--- a/src/common/__tests__/event-emitter.test.ts
+++ b/src/common/__tests__/event-emitter.test.ts
@@ -1,4 +1,5 @@
-import { EventEmitter } from "../event-emitter";
+import type { Expect, TypesAreEqual } from "../../../tests/utils";
+import { type EventArgs, EventEmitter, type EventsOf } from "../event-emitter";
 
 describe("EventEmitter", () => {
 	describe("adding listeners", () => {
@@ -363,10 +364,65 @@ describe("EventEmitter", () => {
 			expect(two).toHaveBeenCalledWith("Hello world");
 		});
 	});
+
+	/* eslint-disable @typescript-eslint/no-unused-vars */
+	describe("types", () => {
+		/**
+		 * Event map
+		 */
+		test("event map", () => {
+			// @ts-expect-error
+			const invalidArgs = new EventEmitter<{
+				invalid: string;
+				valid: [name: string];
+			}>();
+
+			// @ts-expect-error
+			const invalidEventName = new EventEmitter<{
+				[1]: [name: string];
+				valid: [name: string];
+			}>();
+		});
+
+		/**
+		 * Event names.
+		 */
+		test("event name", () => {
+			type eventName = Expect<
+				TypesAreEqual<EventsOf<EventMap>, "message" | "other" | "another" | "empty" | "array" | (string & {})>
+			>;
+
+			// @ts-expect-error
+			type invalid = EventsOf<{
+				invalid: string;
+				valid: [name: string];
+			}>;
+		});
+
+		/**
+		 * Event arguments.
+		 */
+		it("events args", () => {
+			type t = EventArgs<EventMap, "array">;
+
+			type empty = Expect<TypesAreEqual<EventArgs<EventMap, "empty">, []>>;
+			type single = Expect<TypesAreEqual<EventArgs<EventMap, "message">, [message: string]>>;
+			type multiple = Expect<TypesAreEqual<EventArgs<EventMap, "array">, [id: number, name: string]>>;
+
+			type invalid = EventArgs<
+				// @ts-expect-error
+				{ invalid: string },
+				"invalid"
+			>;
+		});
+	});
+	/* eslint-enable @typescript-eslint/no-unused-vars */
 });
 
 type EventMap = {
 	message: [message: string];
 	other: [id: number];
 	another: [id: number];
+	empty: [];
+	array: [id: number, name: string];
 };

--- a/src/common/__tests__/event-emitter.test.ts
+++ b/src/common/__tests__/event-emitter.test.ts
@@ -371,13 +371,13 @@ describe("EventEmitter", () => {
 		 * Event map
 		 */
 		test("event map", () => {
-			// @ts-expect-error
+			// @ts-expect-error: arguments of type `string` are not valid
 			const invalidArgs = new EventEmitter<{
 				invalid: string;
 				valid: [name: string];
 			}>();
 
-			// @ts-expect-error
+			// @ts-expect-error: key of type `Number` is not valid.
 			const invalidEventName = new EventEmitter<{
 				[1]: [name: string];
 				valid: [name: string];
@@ -389,10 +389,10 @@ describe("EventEmitter", () => {
 		 */
 		test("event name", () => {
 			type eventName = Expect<
-				TypesAreEqual<EventsOf<EventMap>, "message" | "other" | "another" | "empty" | "array" | (string & {})>
+				TypesAreEqual<EventsOf<EventMap>, "another" | "array" | "empty" | "message" | "other" | (string & {})>
 			>;
 
-			// @ts-expect-error
+			// @ts-expect-error: arguments of type `string` are not valid
 			type invalid = EventsOf<{
 				invalid: string;
 				valid: [name: string];
@@ -410,7 +410,7 @@ describe("EventEmitter", () => {
 			type multiple = Expect<TypesAreEqual<EventArgs<EventMap, "array">, [id: number, name: string]>>;
 
 			type invalid = EventArgs<
-				// @ts-expect-error
+				// @ts-expect-error: arguments of type `string` are not valid
 				{ invalid: string },
 				"invalid"
 			>;

--- a/src/common/event-emitter.ts
+++ b/src/common/event-emitter.ts
@@ -240,32 +240,15 @@ type EventMap<T> = {
 /**
  * Parsed {@link EventMap} whereby each property is a `string` that denotes an event name, and the associated value type defines the listener arguments.
  */
-export type EventsOf<T> =
-	EventMap<unknown> extends T
-		? string
-		: keyof EventMap<
-				Pick<
-					T,
-					Extract<
-						{
-							[K in keyof T]: K extends string ? K : never;
-						}[keyof T],
-						{
-							[K in keyof T]: T[K] extends unknown[] ? K : never;
-						}[keyof T]
-					>
-				>
-			>;
+export type EventsOf<TMap extends EventMap<TMap>> = keyof TMap | (string & {});
 
 /**
  * Parses the event arguments for the specified event from the event map.
  */
-type EventArgs<TMap, TEvent extends string> = TMap extends {
-	[k in TEvent]: infer TArgs;
-}
-	? TArgs extends [unknown]
-		? TArgs
-		: unknown[]
+export type EventArgs<TMap extends EventMap<TMap>, TEvent extends EventsOf<TMap>> = TEvent extends keyof TMap
+	? TMap[TEvent] extends unknown[]
+		? TMap[TEvent]
+		: never
 	: unknown[];
 
 /**


### PR DESCRIPTION
Fixes an issue whereby event listeners would erroneously resolve the arguments to `unknown[]` every time.