### PR TITLE
feat: add sd-switch and sd-label

### DIFF
--- a/.vscode/html.customData.json
+++ b/.vscode/html.customData.json
@@ -37,6 +37,10 @@
                     "values": [{ "name": "global" }]
                 },
                 {
+                    "name": "label",
+                    "description": "Label of the switch."
+                },
+                {
                     "name": "setting",
                     "description": "Path to the setting where the value should be persisted, for example `name`."
                 }

--- a/.vscode/html.customData.json
+++ b/.vscode/html.customData.json
@@ -3,8 +3,48 @@
     "version": 1.1,
     "tags": [
         {
+            "name": "sd-field",
+            "description": "Element that provides a label for placeholder containing an input.",
+            "attributes": [
+                {
+                    "name": "label",
+                    "description": "Label to show for the field."
+                }
+            ]
+        },
+        {
+            "name": "sd-label",
+            "description": "Element that provides a label for input element.",
+            "attributes": [
+                {
+                    "name": "for",
+                    "description": "Identifier of the element the label is for."
+                }
+            ]
+        },
+        {
+            "name": "sd-switch",
+            "description": "Element that offers persisting a `boolean` via a toggle switch.",
+            "attributes": [
+                {
+                    "name": "disabled",
+                    "description": "Determines whether the input is disabled; default `false`.",
+                    "values": [{ "name": "disabled" }]
+                },
+                {
+                    "name": "global",
+                    "description": "When `true`, the setting will be persisted in the global settings, otherwise it will be persisted in the action's settings; default `false`.",
+                    "values": [{ "name": "global" }]
+                },
+                {
+                    "name": "setting",
+                    "description": "Path to the setting where the value should be persisted, for example `name`."
+                }
+            ]
+        },
+        {
             "name": "sd-textfield",
-            "description": "Text field capable of persisting `string` values to Stream Deck settings.",
+            "description": "Element that offers persisting a `string` via a text input.",
             "attributes": [
                 {
                     "name": "disabled",

--- a/.vscode/html.customData.json
+++ b/.vscode/html.customData.json
@@ -41,6 +41,10 @@
                     "description": "Label of the switch."
                 },
                 {
+                    "name": "on",
+                    "description": "Determines the on/off state of the switch."
+                },
+                {
                     "name": "setting",
                     "description": "Path to the setting where the value should be persisted, for example `name`."
                 }

--- a/src/ui/components/field.ts
+++ b/src/ui/components/field.ts
@@ -11,13 +11,14 @@ export class SDFieldElement extends LitElement {
 	 */
 	public static styles = [
 		css`
-			.sd-field {
+			.field {
 				column-gap: var(--space-xs);
 				display: grid;
 				grid-template-columns: 95px 262px;
 				margin-bottom: var(--space-s);
 			}
-			.sd-field-label {
+
+			.label {
 				align-items: center;
 				display: flex;
 				height: var(--size-2xl);
@@ -36,12 +37,12 @@ export class SDFieldElement extends LitElement {
 	 */
 	public render(): HTMLTemplateResult {
 		return html`
-			<div class="sd-field">
-				<div class="sd-field-label">
-					<sd-label for="__input">${this.label ? `${this.label}:` : undefined}</sd-label>
+			<div class="field">
+				<div class="label">
+					<sd-label for="input">${this.label ? `${this.label}:` : undefined}</sd-label>
 				</div>
-				<div class="sd-field-input">
-					<slot id="__input"></slot>
+				<div>
+					<slot id="input"></slot>
 				</div>
 			</div>
 		`;

--- a/src/ui/components/field.ts
+++ b/src/ui/components/field.ts
@@ -2,7 +2,7 @@ import { css, html, type HTMLTemplateResult, LitElement } from "lit";
 import { customElement, property } from "lit/decorators.js";
 
 /**
- * Field that identifies an input, or group of inputs.
+ * Element that provides a label for placeholder containing an input.
  */
 @customElement("sd-field")
 export class SDFieldElement extends LitElement {
@@ -17,6 +17,9 @@ export class SDFieldElement extends LitElement {
 				display: grid;
 				grid-template-columns: 95px 262px;
 				margin-bottom: var(--space-s);
+			}
+			.sd-field-input {
+				min-height: 32px;
 			}
 		`,
 	];
@@ -34,7 +37,7 @@ export class SDFieldElement extends LitElement {
 		return html`
 			<div class="sd-field">
 				<div class="sd-field-label">
-					<label @click=${this.#focusFirstElement}>${this.label ? this.label + ":" : undefined}</label>
+					<sd-label @click=${this.#focusFirstElement}>${this.label ? `${this.label}:` : undefined}</sd-label>
 				</div>
 				<div class="sd-field-input">
 					<slot></slot>
@@ -59,7 +62,7 @@ export class SDFieldElement extends LitElement {
 declare global {
 	interface HTMLElementTagNameMap {
 		/**
-		 * Field that identifies an input, or group of inputs.
+		 * Element that provides a label for placeholder containing an input.
 		 */
 		"sd-field": SDFieldElement;
 	}

--- a/src/ui/components/field.ts
+++ b/src/ui/components/field.ts
@@ -12,14 +12,18 @@ export class SDFieldElement extends LitElement {
 	public static styles = [
 		css`
 			.sd-field {
-				align-items: baseline;
 				column-gap: var(--space-xs);
 				display: grid;
 				grid-template-columns: 95px 262px;
 				margin-bottom: var(--space-s);
+				min-height: 32px;
+			}
+			.sd-field-label {
+				padding-top: var(--space-xs);
 			}
 			.sd-field-input {
-				min-height: 32px;
+				align-items: center;
+				display: flex;
 			}
 		`,
 	];

--- a/src/ui/components/field.ts
+++ b/src/ui/components/field.ts
@@ -16,14 +16,11 @@ export class SDFieldElement extends LitElement {
 				display: grid;
 				grid-template-columns: 95px 262px;
 				margin-bottom: var(--space-s);
-				min-height: 32px;
 			}
 			.sd-field-label {
-				padding-top: var(--space-xs);
-			}
-			.sd-field-input {
 				align-items: center;
 				display: flex;
+				height: var(--size-2xl);
 			}
 		`,
 	];

--- a/src/ui/components/field.ts
+++ b/src/ui/components/field.ts
@@ -38,25 +38,13 @@ export class SDFieldElement extends LitElement {
 		return html`
 			<div class="sd-field">
 				<div class="sd-field-label">
-					<sd-label @click=${this.#focusFirstElement}>${this.label ? `${this.label}:` : undefined}</sd-label>
+					<sd-label for="__input">${this.label ? `${this.label}:` : undefined}</sd-label>
 				</div>
 				<div class="sd-field-input">
-					<slot></slot>
+					<slot id="__input"></slot>
 				</div>
 			</div>
 		`;
-	}
-
-	/**
-	 * Focuses the first element, that can have focus, within the field.
-	 */
-	#focusFirstElement(): void {
-		for (const el of this.querySelectorAll("*")) {
-			if ("focus" in el && typeof el.focus === "function") {
-				el.focus();
-				return;
-			}
-		}
 	}
 }
 

--- a/src/ui/components/index.ts
+++ b/src/ui/components/index.ts
@@ -1,2 +1,3 @@
 import "./field";
+import "./switch";
 import "./textfield";

--- a/src/ui/components/index.ts
+++ b/src/ui/components/index.ts
@@ -1,3 +1,4 @@
 import "./field";
+import "./label";
 import "./switch";
 import "./textfield";

--- a/src/ui/components/label.ts
+++ b/src/ui/components/label.ts
@@ -20,8 +20,8 @@ export class SDLabelElement extends LitElement {
 	 */
 	constructor() {
 		super();
-		this.role = "label";
 
+		this.role = "label";
 		this.addEventListener("click", (ev: MouseEvent) => {
 			// Stop propagation to prevent multiple triggers of nested labels.
 			ev.stopImmediatePropagation();

--- a/src/ui/components/label.ts
+++ b/src/ui/components/label.ts
@@ -1,4 +1,4 @@
-import { html, LitElement } from "lit";
+import { html, LitElement, type TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { createRef, ref } from "lit/directives/ref.js";
@@ -24,17 +24,27 @@ export class SDLabelElement extends LitElement implements ActivableElement {
 	/**
 	 * @inheritdoc
 	 */
-	public override render() {
+	public activate(): void {
+		const target = this.#getTarget();
+		if (target) {
+			this.#activate(target);
+		}
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public override render(): TemplateResult {
 		return html`<label
 			for=${ifDefined(this.htmlFor)}
-			@click=${() => {
+			@click=${(): void => {
 				// Activate the element the label is for.
 				const target = this.#getTarget();
 				if (target) {
 					this.#activate(target);
 				}
 			}}
-			@mousedown=${(ev: MouseEvent) => {
+			@mousedown=${(ev: MouseEvent): void => {
 				// Disable text selection on double-click.
 				if (ev.detail > 1) {
 					ev.preventDefault();
@@ -45,17 +55,7 @@ export class SDLabelElement extends LitElement implements ActivableElement {
 	}
 
 	/**
-	 * @inheritdoc
-	 */
-	activate(): void {
-		const target = this.#getTarget();
-		if (target) {
-			this.#activate(target);
-		}
-	}
-
-	/**
-	 * Activates the specified element, or the first activable element if the specified one is a {@link HTMLSlotElement}.
+	 * Activates the specified element, or the first activable element if the specified one is a slot.
 	 * @param element Element to activate.
 	 */
 	#activate(element: HTMLElement): void {

--- a/src/ui/components/label.ts
+++ b/src/ui/components/label.ts
@@ -27,14 +27,14 @@ export class SDLabelElement extends LitElement implements ActivableElement {
 	public override render() {
 		return html`<label
 			for=${ifDefined(this.htmlFor)}
-			@mousedown=${(ev: MouseEvent) => {
+			@click=${() => {
 				// Activate the element the label is for.
 				const target = this.#getTarget();
 				if (target) {
 					this.#activate(target);
-					ev.preventDefault();
 				}
-
+			}}
+			@mousedown=${(ev: MouseEvent) => {
 				// Disable text selection on double-click.
 				if (ev.detail > 1) {
 					ev.preventDefault();

--- a/src/ui/components/label.ts
+++ b/src/ui/components/label.ts
@@ -1,0 +1,46 @@
+import { html, LitElement } from "lit";
+import { customElement, property } from "lit/decorators.js";
+import { ifDefined } from "lit/directives/if-defined.js";
+
+/**
+ * Element that provides a label for input element.
+ */
+@customElement("sd-label")
+export class SDLabelElement extends LitElement {
+	/**
+	 * Identifier of the element the label is for.
+	 */
+	@property({ attribute: "for" })
+	public accessor htmlFor: string | undefined;
+
+	/**
+	 * @inheritdoc
+	 */
+	public override render() {
+		return html`<label
+			for=${ifDefined(this.htmlFor)}
+			@mousedown=${(ev: MouseEvent) => {
+				// Focus the element, if we can.
+				if (this.htmlFor) {
+					const element = document.getElementById(this.htmlFor);
+					element?.focus();
+				}
+
+				// Disable text selection on double-click.
+				if (ev.detail > 1) {
+					ev.preventDefault();
+				}
+			}}
+			><slot></slot
+		></label>`;
+	}
+}
+
+declare global {
+	interface HTMLElementTagNameMap {
+		/**
+		 * Element that provides a label for input element.
+		 */
+		"sd-label": SDLabelElement;
+	}
+}

--- a/src/ui/components/switch.ts
+++ b/src/ui/components/switch.ts
@@ -114,6 +114,10 @@ export class SDSwitchElement extends Input<boolean>(LitElement) {
 	 * Sets the on/off state of the switch.
 	 * @param value The on/off state.
 	 */
+	@property({
+		attribute: "on",
+		type: Boolean,
+	})
 	public set isOn(value: boolean) {
 		this.value = value;
 	}
@@ -153,7 +157,7 @@ export class SDSwitchElement extends Input<boolean>(LitElement) {
 					${ref(this.inputRef)}
 					type="checkbox"
 					value=${ifDefined(this.setting)}
-					.checked=${this.value || false}
+					.checked=${this.isOn}
 					.disabled=${this.disabled}
 					@change=${(ev: HTMLInputEvent<HTMLInputElement>): void => {
 						this.isOn = ev.target.checked;

--- a/src/ui/components/switch.ts
+++ b/src/ui/components/switch.ts
@@ -101,6 +101,11 @@ export class SDSwitchElement extends Input<boolean>(LitElement) {
 	/**
 	 * @inheritdoc
 	 */
+	protected override focusBehavior: "click" | "focus" = "click";
+
+	/**
+	 * @inheritdoc
+	 */
 	public override render(): TemplateResult {
 		return html`
 			<label
@@ -114,7 +119,7 @@ export class SDSwitchElement extends Input<boolean>(LitElement) {
 				}}
 			>
 				<input
-					${ref(this.focusElement)}
+					${ref(this.focusDelegate)}
 					type="checkbox"
 					value=${ifDefined(this.setting)}
 					.checked=${this.value || false}

--- a/src/ui/components/switch.ts
+++ b/src/ui/components/switch.ts
@@ -99,6 +99,7 @@ export class SDSwitchElement extends Input<boolean>(LitElement) {
 	 */
 	constructor() {
 		super();
+
 		this.role = "checkbox";
 	}
 

--- a/src/ui/components/switch.ts
+++ b/src/ui/components/switch.ts
@@ -86,7 +86,7 @@ export class SDSwitchElement extends Input<boolean>(LitElement) {
 	 * Gets the on/off state of the switch.
 	 * @returns Whether the switch is on/off.
 	 */
-	public get on(): boolean {
+	public get isOn(): boolean {
 		return !!this.value;
 	}
 
@@ -94,7 +94,7 @@ export class SDSwitchElement extends Input<boolean>(LitElement) {
 	 * Sets the on/off state of the switch.
 	 * @param value The on/off state.
 	 */
-	public set on(value: boolean) {
+	public set isOn(value: boolean) {
 		this.value = value;
 	}
 
@@ -109,13 +109,18 @@ export class SDSwitchElement extends Input<boolean>(LitElement) {
 	public override render(): TemplateResult {
 		return html`
 			<label
-				aria-checked=${this.on}
+				aria-checked=${this.isOn}
 				aria-disabled=${this.disabled}
 				tabindex=${ifDefined(this.disabled ? undefined : 0)}
 				@keydown=${(ev: KeyboardEvent) => {
+					// Toggle switch on space bar key.
 					if (ev.code === "Space") {
-						this.on = !this.on;
+						this.isOn = !this.isOn;
 					}
+				}}
+				@mousedown=${(ev: MouseEvent) => {
+					// Prevent focus on mouse down.
+					ev.preventDefault();
 				}}
 			>
 				<input
@@ -125,10 +130,10 @@ export class SDSwitchElement extends Input<boolean>(LitElement) {
 					.checked=${this.value || false}
 					.disabled=${this.disabled}
 					@change=${(ev: HTMLInputEvent<HTMLInputElement>) => {
-						this.on = ev.target.checked;
+						this.isOn = ev.target.checked;
 					}}
 				/>
-				<div class="thumb" role="button" aria-pressed=${this.on}></div>
+				<div class="thumb" role="button" aria-pressed=${this.isOn}></div>
 			</label>
 		`;
 	}

--- a/src/ui/components/switch.ts
+++ b/src/ui/components/switch.ts
@@ -86,6 +86,14 @@ export class SDSwitchElement extends Input<boolean>(LitElement) {
 	];
 
 	/**
+	 * Initializes a new instance of the {@link SDSwitchElement} class.
+	 */
+	constructor() {
+		super();
+		this.internals.role = "checkbox";
+	}
+
+	/**
 	 * Gets the on/off state of the switch.
 	 * @returns Whether the switch is on/off.
 	 */
@@ -104,11 +112,6 @@ export class SDSwitchElement extends Input<boolean>(LitElement) {
 	/**
 	 * @inheritdoc
 	 */
-	protected override focusBehavior: "click" | "focus" = "click";
-
-	/**
-	 * @inheritdoc
-	 */
 	public override render(): TemplateResult {
 		return html`
 			<label
@@ -123,7 +126,7 @@ export class SDSwitchElement extends Input<boolean>(LitElement) {
 				}}
 			>
 				<input
-					${ref(this.focusDelegate)}
+					${ref(this.inputRef)}
 					type="checkbox"
 					value=${ifDefined(this.setting)}
 					.checked=${this.value || false}
@@ -135,6 +138,14 @@ export class SDSwitchElement extends Input<boolean>(LitElement) {
 				<div class="thumb" role="button" aria-pressed=${this.isOn}></div>
 			</label>
 		`;
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	protected override willUpdate(_changedProperties: Map<PropertyKey, unknown>): void {
+		super.willUpdate(_changedProperties);
+		this.internals.ariaChecked = this.isOn ? "checked" : null;
 	}
 }
 

--- a/src/ui/components/switch.ts
+++ b/src/ui/components/switch.ts
@@ -1,0 +1,144 @@
+import { css, html, LitElement, type TemplateResult } from "lit";
+import { customElement } from "lit/decorators.js";
+import { ifDefined } from "lit/directives/if-defined.js";
+
+import { Input } from "../mixins/input";
+import type { HTMLInputEvent } from "../utils";
+
+/**
+ * Element that offers a binary choice, such as on/off.
+ */
+@customElement("sd-switch")
+export class SDSwitchElement extends Input<boolean>(LitElement) {
+	/**
+	 * @inheritdoc
+	 */
+	public static styles = [
+		super.styles ?? [],
+		css`
+			/**
+             * Track
+             */
+
+			label {
+				align-items: center;
+				background: var(--color-surface-strong);
+				border: solid var(--border-width-thick) var(--color-page);
+				border-radius: var(--rounding-full);
+				cursor: pointer;
+				display: inline-flex;
+				margin: var(--space-xs) var(--space-2xs) var(--space-xs) calc(var(--border-width-thick) * -1);
+				padding: 0px var(--space-3xs);
+				transition: 0.2;
+				height: var(--size-m);
+				width: var(--size-xl);
+				user-select: none;
+			}
+
+			label[aria-disabled="false"]:has(input:checked) {
+				background: var(--color-surface-accent);
+			}
+
+			label[aria-disabled="true"] {
+				cursor: default;
+				background: var(--color-surface-disabled);
+			}
+
+			label:focus {
+				outline: solid var(--border-width-thick) var(--color-surface-accent);
+			}
+
+			input {
+				display: none;
+			}
+
+			/**
+             * Thumb
+             */
+
+			.thumb {
+				background: var(--color-content-primary);
+				border: none;
+				outline: none;
+				border-radius: var(--rounding-full);
+				height: var(--size-s);
+				transform: translateX(0);
+				transition: all 200ms;
+				width: var(--size-s);
+			}
+
+			input:checked + .thumb {
+				transform: translateX(100%);
+			}
+
+			label[aria-disabled="false"] .thumb {
+				background: var(--color-surface-ondark);
+			}
+
+			label[aria-disabled="true"] .thumb {
+				background: var(--color-surface-strong);
+			}
+		`,
+	];
+
+	/**
+	 * Gets the on/off state of the switch.
+	 * @returns Whether the switch is on/off.
+	 */
+	public get on(): boolean {
+		return !!this.value;
+	}
+
+	/**
+	 * Sets the on/off state of the switch.
+	 * @param value The on/off state.
+	 */
+	public set on(value: boolean) {
+		this.value = value;
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public override render(): TemplateResult {
+		return html`
+			<label
+				aria-checked=${this.on}
+				aria-disabled=${this.disabled}
+				tabindex=${ifDefined(this.disabled ? undefined : 0)}
+				@keydown=${(ev: KeyboardEvent) => {
+					if (ev.code === "Space") {
+						this.on = !this.on;
+					}
+				}}
+			>
+				<input
+					type="checkbox"
+					value=${ifDefined(this.setting)}
+					.checked=${this.value || false}
+					.disabled=${this.disabled}
+					@change=${(ev: HTMLInputEvent<HTMLInputElement>) => {
+						this.on = ev.target.checked;
+					}}
+				/>
+				<div class="thumb" role="button" aria-pressed=${this.on}></div>
+			</label>
+		`;
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public override focus(): void {
+		this.on = !this.on;
+	}
+}
+
+declare global {
+	interface HTMLElementTagNameMap {
+		/**
+		 * Element that offers a binary choice, such as on/off.
+		 */
+		"sd-switch": SDSwitchElement;
+	}
+}

--- a/src/ui/components/switch.ts
+++ b/src/ui/components/switch.ts
@@ -28,7 +28,7 @@ export class SDSwitchElement extends Input<boolean>(LitElement) {
 				border-radius: var(--rounding-full);
 				cursor: pointer;
 				display: inline-flex;
-				margin: 6px var(--space-2xs) 6px 0;
+				margin: var(--space-xs) var(--space-xs) var(--space-xs) 0;
 				outline: none;
 				padding: 0px var(--space-3xs);
 				transition: 0.2;
@@ -46,7 +46,7 @@ export class SDSwitchElement extends Input<boolean>(LitElement) {
 				background: var(--color-surface-disabled);
 			}
 
-			label:focus {
+			label:focus-visible {
 				box-shadow: var(--highlight-box-shadow);
 				outline: var(--highlight-outline--focus);
 				outline-offset: var(--highlight-outline-offset);
@@ -120,10 +120,6 @@ export class SDSwitchElement extends Input<boolean>(LitElement) {
 					if (ev.code === "Space") {
 						this.isOn = !this.isOn;
 					}
-				}}
-				@mousedown=${(ev: MouseEvent) => {
-					// Prevent focus on mouse down.
-					ev.preventDefault();
 				}}
 			>
 				<input

--- a/src/ui/components/switch.ts
+++ b/src/ui/components/switch.ts
@@ -127,7 +127,7 @@ export class SDSwitchElement extends Input<boolean>(LitElement) {
 	/**
 	 * @inheritdoc
 	 */
-	public override click() {
+	public override click(): void {
 		if (!this.disabled) {
 			this.isOn = !this.isOn;
 		}

--- a/src/ui/components/switch.ts
+++ b/src/ui/components/switch.ts
@@ -28,7 +28,7 @@ export class SDSwitchElement extends Input<boolean>(LitElement) {
 				border-radius: var(--rounding-full);
 				cursor: pointer;
 				display: inline-flex;
-				margin: var(--space-xs) var(--space-2xs) var(--space-xs) calc(var(--border-width-thick) * -1);
+				margin: 6px var(--space-2xs) 6px calc(var(--border-width-thick) * -1);
 				padding: 0px var(--space-3xs);
 				transition: 0.2;
 				height: var(--size-m);

--- a/src/ui/components/switch.ts
+++ b/src/ui/components/switch.ts
@@ -6,7 +6,7 @@ import { Input } from "../mixins/input";
 import type { HTMLInputEvent } from "../utils";
 
 /**
- * Element that offers a binary choice, such as on/off.
+ * Element that offers persisting a `boolean` via a toggle switch.
  */
 @customElement("sd-switch")
 export class SDSwitchElement extends Input<boolean>(LitElement) {
@@ -137,7 +137,7 @@ export class SDSwitchElement extends Input<boolean>(LitElement) {
 declare global {
 	interface HTMLElementTagNameMap {
 		/**
-		 * Element that offers a binary choice, such as on/off.
+		 * Element that offers persisting a `boolean` via a toggle switch.
 		 */
 		"sd-switch": SDSwitchElement;
 	}

--- a/src/ui/components/switch.ts
+++ b/src/ui/components/switch.ts
@@ -118,10 +118,10 @@ export class SDSwitchElement extends Input<boolean>(LitElement) {
 				aria-checked=${this.isOn}
 				aria-disabled=${this.disabled}
 				tabindex=${ifDefined(this.disabled ? undefined : 0)}
-				@click=${(ev: MouseEvent) => {
+				@click=${(ev: MouseEvent): void => {
 					ev.stopPropagation();
 				}}
-				@keydown=${(ev: KeyboardEvent) => {
+				@keydown=${(ev: KeyboardEvent): void => {
 					// Toggle switch on space bar key.
 					if (ev.code === "Space") {
 						this.isOn = !this.isOn;
@@ -134,7 +134,7 @@ export class SDSwitchElement extends Input<boolean>(LitElement) {
 					value=${ifDefined(this.setting)}
 					.checked=${this.value || false}
 					.disabled=${this.disabled}
-					@change=${(ev: HTMLInputEvent<HTMLInputElement>) => {
+					@change=${(ev: HTMLInputEvent<HTMLInputElement>): void => {
 						this.isOn = ev.target.checked;
 					}}
 				/>

--- a/src/ui/components/switch.ts
+++ b/src/ui/components/switch.ts
@@ -1,6 +1,7 @@
 import { css, html, LitElement, type TemplateResult } from "lit";
 import { customElement } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
+import { ref } from "lit/directives/ref.js";
 
 import { Input } from "../mixins/input";
 import type { HTMLInputEvent } from "../utils";
@@ -113,6 +114,7 @@ export class SDSwitchElement extends Input<boolean>(LitElement) {
 				}}
 			>
 				<input
+					${ref(this.focusElement)}
 					type="checkbox"
 					value=${ifDefined(this.setting)}
 					.checked=${this.value || false}
@@ -124,13 +126,6 @@ export class SDSwitchElement extends Input<boolean>(LitElement) {
 				<div class="thumb" role="button" aria-pressed=${this.on}></div>
 			</label>
 		`;
-	}
-
-	/**
-	 * @inheritdoc
-	 */
-	public override focus(): void {
-		this.on = !this.on;
 	}
 }
 

--- a/src/ui/components/switch.ts
+++ b/src/ui/components/switch.ts
@@ -1,5 +1,5 @@
 import { css, html, LitElement, type TemplateResult } from "lit";
-import { customElement } from "lit/decorators.js";
+import { customElement, property } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { ref } from "lit/directives/ref.js";
 
@@ -18,18 +18,33 @@ export class SDSwitchElement extends Input<boolean>(LitElement) {
 		super.styles ?? [],
 		css`
 			/**
+			 * Containers
+			 */
+
+			sd-label {
+				outline: none;
+			}
+
+			.container {
+				align-items: center;
+				display: inline-flex;
+			}
+
+			input {
+				display: none;
+			}
+
+			/**
              * Track
              */
 
-			label {
+			.track {
 				align-items: center;
 				background: var(--color-surface-strong);
-				border: none;
 				border-radius: var(--rounding-full);
 				cursor: pointer;
 				display: inline-flex;
 				margin: var(--space-xs) var(--space-xs) var(--space-xs) 0;
-				outline: none;
 				padding: 0px var(--space-3xs);
 				transition: 0.2;
 				height: var(--size-m);
@@ -37,23 +52,19 @@ export class SDSwitchElement extends Input<boolean>(LitElement) {
 				user-select: none;
 			}
 
-			label[aria-disabled="false"]:has(input:checked) {
+			sd-label[aria-disabled="false"]:has(input:checked) .track {
 				background: var(--color-surface-accent);
 			}
 
-			label[aria-disabled="true"] {
-				cursor: default;
+			sd-label[aria-disabled="true"] .track {
 				background: var(--color-surface-disabled);
+				cursor: default;
 			}
 
-			label:focus-visible {
+			sd-label:focus-visible .track {
 				box-shadow: var(--highlight-box-shadow);
 				outline: var(--highlight-outline--focus);
 				outline-offset: var(--highlight-outline-offset);
-			}
-
-			input {
-				display: none;
 			}
 
 			/**
@@ -62,8 +73,6 @@ export class SDSwitchElement extends Input<boolean>(LitElement) {
 
 			.thumb {
 				background: var(--color-content-primary);
-				border: none;
-				outline: none;
 				border-radius: var(--rounding-full);
 				height: var(--size-s);
 				transform: translateX(0);
@@ -71,15 +80,15 @@ export class SDSwitchElement extends Input<boolean>(LitElement) {
 				width: var(--size-s);
 			}
 
-			input:checked + .thumb {
+			sd-label:has(input:checked) .thumb {
 				transform: translateX(100%);
 			}
 
-			label[aria-disabled="false"] .thumb {
+			sd-label[aria-disabled="false"] .thumb {
 				background: var(--color-surface-ondark);
 			}
 
-			label[aria-disabled="true"] .thumb {
+			sd-label[aria-disabled="true"] .thumb {
 				background: var(--color-surface-strong);
 			}
 		`,
@@ -90,7 +99,7 @@ export class SDSwitchElement extends Input<boolean>(LitElement) {
 	 */
 	constructor() {
 		super();
-		this.internals.role = "checkbox";
+		this.role = "checkbox";
 	}
 
 	/**
@@ -110,21 +119,33 @@ export class SDSwitchElement extends Input<boolean>(LitElement) {
 	}
 
 	/**
+	 * Label of the switch.
+	 */
+	@property()
+	public accessor label: string | undefined;
+
+	/**
+	 * @inheritdoc
+	 */
+	public override click() {
+		if (!this.disabled) {
+			this.isOn = !this.isOn;
+		}
+	}
+
+	/**
 	 * @inheritdoc
 	 */
 	public override render(): TemplateResult {
 		return html`
-			<label
-				aria-checked=${this.isOn}
+			<sd-label
 				aria-disabled=${this.disabled}
 				tabindex=${ifDefined(this.disabled ? undefined : 0)}
-				@click=${(ev: MouseEvent): void => {
-					ev.stopPropagation();
-				}}
 				@keydown=${(ev: KeyboardEvent): void => {
 					// Toggle switch on space bar key.
 					if (ev.code === "Space") {
 						this.isOn = !this.isOn;
+						ev.preventDefault();
 					}
 				}}
 			>
@@ -138,8 +159,13 @@ export class SDSwitchElement extends Input<boolean>(LitElement) {
 						this.isOn = ev.target.checked;
 					}}
 				/>
-				<div class="thumb" role="button" aria-pressed=${this.isOn}></div>
-			</label>
+				<div class="container">
+					<div class="track" role="button">
+						<div class="thumb"></div>
+					</div>
+					${this.label}
+				</div>
+			</sd-label>
 		`;
 	}
 
@@ -148,7 +174,7 @@ export class SDSwitchElement extends Input<boolean>(LitElement) {
 	 */
 	protected override willUpdate(_changedProperties: Map<PropertyKey, unknown>): void {
 		super.willUpdate(_changedProperties);
-		this.internals.ariaChecked = this.isOn ? "checked" : null;
+		this.ariaChecked = this.isOn ? "checked" : null;
 	}
 }
 

--- a/src/ui/components/switch.ts
+++ b/src/ui/components/switch.ts
@@ -24,11 +24,12 @@ export class SDSwitchElement extends Input<boolean>(LitElement) {
 			label {
 				align-items: center;
 				background: var(--color-surface-strong);
-				border: solid var(--border-width-thick) var(--color-page);
+				border: none;
 				border-radius: var(--rounding-full);
 				cursor: pointer;
 				display: inline-flex;
-				margin: 6px var(--space-2xs) 6px calc(var(--border-width-thick) * -1);
+				margin: 6px var(--space-2xs) 6px 0;
+				outline: none;
 				padding: 0px var(--space-3xs);
 				transition: 0.2;
 				height: var(--size-m);
@@ -46,7 +47,9 @@ export class SDSwitchElement extends Input<boolean>(LitElement) {
 			}
 
 			label:focus {
-				outline: solid var(--border-width-thick) var(--color-surface-accent);
+				box-shadow: var(--highlight-box-shadow);
+				outline: var(--highlight-outline--focus);
+				outline-offset: var(--highlight-outline-offset);
 			}
 
 			input {

--- a/src/ui/components/switch.ts
+++ b/src/ui/components/switch.ts
@@ -118,6 +118,9 @@ export class SDSwitchElement extends Input<boolean>(LitElement) {
 				aria-checked=${this.isOn}
 				aria-disabled=${this.disabled}
 				tabindex=${ifDefined(this.disabled ? undefined : 0)}
+				@click=${(ev: MouseEvent) => {
+					ev.stopPropagation();
+				}}
 				@keydown=${(ev: KeyboardEvent) => {
 					// Toggle switch on space bar key.
 					if (ev.code === "Space") {

--- a/src/ui/components/textfield.ts
+++ b/src/ui/components/textfield.ts
@@ -31,21 +31,26 @@ export class SDTextFieldElement extends Input<string>(LitElement) {
 				min-height: 32px;
 				width: 224px;
 			}
+
 			input::placeholder {
 				color: var(--color-content-secondary);
 			}
+
 			input:disabled {
 				color: var(--color-content-disabled);
 			}
+
 			input:focus,
 			input:invalid {
 				box-shadow: var(--highlight-box-shadow);
 				outline-offset: var(--highlight-outline-offset);
 			}
+
 			input:focus,
 			input:focus:invalid {
 				outline: var(--highlight-outline--focus);
 			}
+
 			input:invalid {
 				outline: var(--highlight-outline--invalid);
 			}
@@ -57,7 +62,9 @@ export class SDTextFieldElement extends Input<string>(LitElement) {
 	 */
 	constructor() {
 		super();
+
 		this.debounceSave = true;
+		this.role = "textbox";
 	}
 
 	/**

--- a/src/ui/components/textfield.ts
+++ b/src/ui/components/textfield.ts
@@ -100,7 +100,7 @@ export class SDTextFieldElement extends Input<string>(LitElement) {
 	 */
 	public override render(): TemplateResult {
 		return html`<input
-			${ref(this.focusElement)}
+			${ref(this.focusDelegate)}
 			maxlength=${ifDefined(this.maxLength)}
 			pattern=${ifDefined(this.pattern)}
 			placeholder=${ifDefined(this.placeholder)}

--- a/src/ui/components/textfield.ts
+++ b/src/ui/components/textfield.ts
@@ -7,7 +7,7 @@ import { Input } from "../mixins/input";
 import type { HTMLInputEvent } from "../utils";
 
 /**
- * Text field capable of persisting `string` values to Stream Deck settings.
+ * Element that offers persisting a `string` via a text input.
  */
 @customElement("sd-textfield")
 export class SDTextFieldElement extends Input<string>(LitElement) {
@@ -121,7 +121,7 @@ export class SDTextFieldElement extends Input<string>(LitElement) {
 declare global {
 	interface HTMLElementTagNameMap {
 		/**
-		 * Text field capable of persisting `string` values to Stream Deck settings.
+		 * Element that offers persisting a `string` via a text input.
 		 */
 		"sd-textfield": SDTextFieldElement;
 	}

--- a/src/ui/components/textfield.ts
+++ b/src/ui/components/textfield.ts
@@ -19,13 +19,14 @@ export class SDTextFieldElement extends Input<string>(LitElement) {
 		css`
 			input {
 				background-color: var(--color-surface);
-				border: solid var(--border-width-thick) var(--color-page);
+				border: none;
 				border-radius: var(--rounding-m);
 				color: var(--color-content-primary);
 				font-family: var(--typography-body-m-family);
 				font-size: var(--typography-body-m-size);
 				font-weight: var(--typography-body-m-weight);
-				margin: calc(var(--border-width-thick) * -1);
+				height: var(--size-2xl);
+				outline: none;
 				padding: 0 var(--space-xs);
 				min-height: 32px;
 				width: 224px;
@@ -37,11 +38,16 @@ export class SDTextFieldElement extends Input<string>(LitElement) {
 				color: var(--color-content-disabled);
 			}
 			input:focus,
+			input:invalid {
+				box-shadow: var(--highlight-box-shadow);
+				outline-offset: var(--highlight-outline-offset);
+			}
+			input:focus,
 			input:focus:invalid {
-				outline: solid var(--border-width-thick) var(--color-surface-accent);
+				outline: var(--highlight-outline--focus);
 			}
 			input:invalid {
-				outline: solid var(--border-width-thick) var(--color-surface-negative);
+				outline: var(--highlight-outline--invalid);
 			}
 		`,
 	];

--- a/src/ui/components/textfield.ts
+++ b/src/ui/components/textfield.ts
@@ -106,7 +106,7 @@ export class SDTextFieldElement extends Input<string>(LitElement) {
 	 */
 	public override render(): TemplateResult {
 		return html`<input
-			${ref(this.focusDelegate)}
+			${ref(this.inputRef)}
 			maxlength=${ifDefined(this.maxLength)}
 			pattern=${ifDefined(this.pattern)}
 			placeholder=${ifDefined(this.placeholder)}

--- a/src/ui/css/main.css
+++ b/src/ui/css/main.css
@@ -1,3 +1,10 @@
+:root {
+	--highlight-box-shadow: 0 0 0 var(--border-width-thick) var(--color-page);
+	--highlight-outline-offset: var(--border-width-thick);
+	--highlight-outline--focus: solid var(--border-width-thick) var(--color-surface-accent);
+	--highlight-outline--invalid: solid var(--border-width-thick) var(--color-surface-negative);
+}
+
 body {
 	background-color: var(--color-page);
 	color: var(--color-content-primary);

--- a/src/ui/mixins/input.ts
+++ b/src/ui/mixins/input.ts
@@ -22,6 +22,31 @@ export const Input = <TValue extends JsonValue, TBase extends Constructor<LitEle
 		/**
 		 * @inheritdoc
 		 */
+		public static shadowRootOptions = { ...LitElement.shadowRootOptions, delegatesFocus: true };
+
+		/**
+		 * Enable inputs to work with labels.
+		 */
+		public static formAssociated = true;
+
+		/**
+		 * Initializes a new instance of the {@link InputClass} class.
+		 * @param args Constructor arguments.
+		 */
+		constructor(...args: any[]) {
+			super(args);
+
+			this.addEventListener("click", (ev: MouseEvent) => {
+				if (this.focusElement.value && ev.target !== document.elementFromPoint(ev.x, ev.y)) {
+					this.focusElement.value.click();
+					ev.preventDefault();
+				}
+			});
+		}
+
+		/**
+		 * @inheritdoc
+		 */
 		@property({
 			reflect: true,
 			type: Boolean,
@@ -86,18 +111,6 @@ export const Input = <TValue extends JsonValue, TBase extends Constructor<LitEle
 			this.#signal = undefined;
 
 			super.disconnectedCallback();
-		}
-
-		/**
-		 * @inheritdoc
-		 */
-		public focus(): void {
-			if (!this.focusElement.value) {
-				console.warn("Unable to focus input; a focus element was not specified");
-				return;
-			}
-
-			this.focusElement.value.focus();
 		}
 
 		/**
@@ -179,12 +192,7 @@ export declare class InputMixin<T extends JsonValue> {
 	protected debounceSave: boolean;
 
 	/**
-	 * Element that will gain focus when calling `focus()`.
+	 * Element that will gain focus when an associated label is clicked.
 	 */
 	protected focusElement: Ref<HTMLInputElement>;
-
-	/**
-	 * Focuses the input.
-	 */
-	public focus(): void;
 }

--- a/src/ui/mixins/input.ts
+++ b/src/ui/mixins/input.ts
@@ -20,17 +20,27 @@ export const Input = <TValue extends JsonValue, TBase extends Constructor<LitEle
 	 */
 	class InputClass extends superClass {
 		/**
-		 * @inheritdoc
-		 */
-		public static shadowRootOptions = { ...LitElement.shadowRootOptions, delegatesFocus: true };
-
-		/**
 		 * Enable inputs to work with labels.
 		 */
 		public static formAssociated = true;
 
 		/**
-		 * Element internals that allow for configuring how the element interacts with forms.
+		 * @inheritdoc
+		 */
+		public static shadowRootOptions = { ...LitElement.shadowRootOptions, delegatesFocus: true };
+
+		/**
+		 * @inheritdoc
+		 */
+		protected debounceSave: boolean = false;
+
+		/**
+		 * @inheritdoc
+		 */
+		protected inputRef: Ref<HTMLInputElement> = createRef();
+
+		/**
+		 * @inheritdoc
 		 */
 		protected internals: ElementInternals;
 
@@ -45,9 +55,10 @@ export const Input = <TValue extends JsonValue, TBase extends Constructor<LitEle
 		#value: TValue | undefined;
 
 		/**
-		 * Initializes a new instance of the {@link InputClass} class.
+		 * Initializes a new instance of the {@link InputMixin} class.
 		 * @param args Constructor arguments.
 		 */
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		constructor(...args: any[]) {
 			super(args);
 
@@ -88,16 +99,6 @@ export const Input = <TValue extends JsonValue, TBase extends Constructor<LitEle
 		public accessor setting: string | undefined;
 
 		/**
-		 * @inheritdoc
-		 */
-		protected debounceSave: boolean = false;
-
-		/**
-		 * @inheritdoc
-		 */
-		protected inputRef: Ref<HTMLInputElement> = createRef();
-
-		/**
 		 * Gets the current input value.
 		 * @returns The value.
 		 */
@@ -118,7 +119,7 @@ export const Input = <TValue extends JsonValue, TBase extends Constructor<LitEle
 		/**
 		 * @inheritdoc
 		 */
-		public activate() {
+		public activate(): void {
 			// Blur the active element first.
 			if (document.activeElement && document.activeElement instanceof HTMLElement) {
 				document.activeElement.blur();
@@ -226,20 +227,20 @@ export declare class InputMixin<T extends JsonValue> {
 	protected debounceSave: boolean;
 
 	/**
-	 * Element internals that allow for configuring how the element interacts with forms.
-	 */
-	protected internals: ElementInternals;
-
-	/**
 	 * Element that represents the primary input element.
 	 */
 	protected inputRef: Ref<HTMLInputElement>;
 
 	/**
+	 * Element internals that allow for configuring how the element interacts with forms.
+	 */
+	protected internals: ElementInternals;
+
+	/**
 	 * Activates the element; activation behavior is dependent on the role of the element, for example when the element
 	 * is a `"checkbox"`, it is clicked, whereas a text input gains focus.
 	 */
-	activate(): void;
+	public activate(): void;
 }
 
 /**
@@ -247,7 +248,7 @@ export declare class InputMixin<T extends JsonValue> {
  * @param elem Element to check.
  * @returns `true` when the element can be activated; otherwise `false`.
  */
-export function isActivable(elem: Element): elem is HTMLElement & ActivableElement {
+export function isActivable(elem: Element): elem is ActivableElement & HTMLElement {
 	return elem instanceof HTMLElement && "activate" in elem && typeof elem.activate === "function";
 }
 


### PR DESCRIPTION
- Adds `sd-switch` component, allowing for a switch to be turned on/off.
- Adds `sd-label` component that allows for more advanced labelling.
  - Supports inputs within slots.
  - Supports identifying inputs within shadow DOM.