### PR TITLE
feat: add `<sd-checkbox />` and `<sd-checkboxgroup />`

### DIFF
--- a/src/ui/components/checkbox-group.ts
+++ b/src/ui/components/checkbox-group.ts
@@ -36,13 +36,13 @@ export class SDCheckboxGroupElement extends List(Input<(boolean | number | strin
 					return html`<sd-checkbox
 						.checked=${(this.value ?? []).findIndex((value) => value === opt.value) > -1}
 						.disabled=${opt.disabled}
+						.label=${opt.label}
 						@change=${(ev: Event): void => {
 							if (ev.target instanceof SDCheckboxElement) {
 								this.#handleChange(ev.target.checked, opt.value);
 							}
 						}}
-						>${opt.textContent}</sd-checkbox
-					>`;
+					/>`;
 				},
 			)}
 		`;

--- a/src/ui/components/checkbox-group.ts
+++ b/src/ui/components/checkbox-group.ts
@@ -1,0 +1,79 @@
+import { css, html, LitElement, type TemplateResult } from "lit";
+import { customElement } from "lit/decorators.js";
+import { repeat } from "lit/directives/repeat.js";
+
+import { Input } from "../mixins/input";
+import { List } from "../mixins/list";
+import { SDCheckboxElement } from "./checkbox";
+import { type SDOptionElement } from "./option";
+
+/**
+ * Element that offers persisting an set of values, from a group of checkbox options.
+ */
+@customElement("sd-checkboxgroup")
+export class SDCheckboxGroupElement extends List(Input<(boolean | number | string)[]>(LitElement)) {
+	/**
+	 * @inheritdoc
+	 */
+	public static styles = [
+		super.styles ?? [],
+		css`
+			sd-checkbox {
+				display: flex;
+			}
+		`,
+	];
+
+	/**
+	 * @inheritdoc
+	 */
+	public override render(): TemplateResult {
+		return html`
+			${repeat(
+				this.items,
+				(opt) => opt,
+				(opt) => {
+					return html`<sd-checkbox
+						.checked=${(this.value ?? []).findIndex((value) => value === opt.value) > -1}
+						.disabled=${opt.disabled}
+						@change=${(ev: Event): void => {
+							if (ev.target instanceof SDCheckboxElement) {
+								this.#handleChange(ev.target.checked, opt.value);
+							}
+						}}
+						>${opt.textContent}</sd-checkbox
+					>`;
+				},
+			)}
+		`;
+	}
+
+	/**
+	 * Handles a checkbox state changing.
+	 * @param checked Whether the checkbox is checked.
+	 * @param value Value the checkbox represents.
+	 */
+	#handleChange(checked: boolean, value: SDOptionElement["value"]): void {
+		if (value === undefined) {
+			return;
+		}
+
+		const values = new Set(this.value);
+		if (checked) {
+			values.add(value);
+		} else {
+			values.delete(value);
+		}
+
+		this.value = Array.from(values);
+	}
+}
+
+declare global {
+	interface HTMLElementTagNameMap {
+		/**
+		 * Element that offers persisting an set of values, from a group of checkbox options.
+		 */
+		"sd-checkboxgroup": SDCheckboxGroupElement;
+	}
+}

--- a/src/ui/components/checkbox.ts
+++ b/src/ui/components/checkbox.ts
@@ -7,7 +7,7 @@ import { Input } from "../mixins/input";
 import { type HTMLInputEvent, preventDoubleClickSelection } from "../utils";
 
 /**
- * Element that offers a boolean option in the form of a checkbox.
+ * Element that offers persisting a `boolean` via a checkbox.
  */
 @customElement("sd-checkbox")
 export class SDCheckboxElement extends Input(LitElement) {
@@ -174,7 +174,7 @@ export class SDCheckboxElement extends Input(LitElement) {
 declare global {
 	interface HTMLElementTagNameMap {
 		/**
-		 * Element that offers a boolean option in the form of a checkbox.
+		 * Element that offers persisting a `boolean` via a checkbox.
 		 */
 		"sd-checkbox": SDCheckboxElement;
 	}

--- a/src/ui/components/checkbox.ts
+++ b/src/ui/components/checkbox.ts
@@ -1,0 +1,170 @@
+import { css, html, LitElement, type TemplateResult } from "lit";
+import { customElement } from "lit/decorators.js";
+import { ifDefined } from "lit/directives/if-defined.js";
+import { ref } from "lit/directives/ref.js";
+
+import { Input } from "../mixins/input";
+import { type HTMLInputEvent, preventDoubleClickSelection } from "../utils";
+
+/**
+ * Element that offers a boolean option in the form of a checkbox.
+ */
+@customElement("sd-checkbox")
+export class SDCheckboxElement extends Input(LitElement) {
+	/**
+	 * @inheritdoc
+	 */
+	public static styles = [
+		super.styles ?? [],
+		css`
+			/**
+			 * Container
+			 */
+
+			label {
+				align-items: center;
+				display: flex;
+				display: inline-flex;
+				margin: var(--space-xs) 0;
+				outline: none;
+
+				&:focus-visible .checkbox {
+					box-shadow: var(--highlight-box-shadow);
+					outline: var(--highlight-outline--focus);
+					outline-offset: var(--highlight-outline-offset);
+				}
+
+				&:has(input:disabled) {
+					color: var(--color-content-disabled);
+				}
+			}
+
+			/**
+             * Checkbox and label
+             */
+
+			.checkbox {
+				border: solid 1px var(--color-border-strong);
+				border-radius: var(--rounding-m);
+				box-sizing: border-box;
+				height: var(--size-m);
+				margin-right: var(--space-xs);
+				width: var(--size-m);
+				user-select: none;
+			}
+
+			.checkbox > svg {
+				visibility: hidden;
+			}
+
+			span {
+				margin-right: var(--space-xs);
+			}
+
+			/**
+             * Input and states
+             */
+
+			input {
+				display: none;
+
+				/* Checked */
+				&:checked + .checkbox {
+					border-width: 0;
+					background-color: var(--color-surface-accent);
+
+					& > svg {
+						color: var(--color-content-ondark);
+						visibility: visible;
+					}
+				}
+
+				/* Checked and disabled */
+				&:checked:disabled + .checkbox {
+					background-color: var(--color-surface-disabled);
+
+					& > svg {
+						color: var(--color-content-disabled);
+						visibility: visible;
+					}
+				}
+
+				/* Disabled */
+				&:disabled + .checkbox {
+					border-color: var(--color-border-subtle-disabled);
+				}
+			}
+		`,
+	];
+
+	/**
+	 * Gets the checked state.
+	 * @returns `true` when the checkbox is checked; otherwise `false`.
+	 */
+	public get checked(): boolean {
+		return !!this.value;
+	}
+
+	/**
+	 * Sets the checked state.
+	 * @param value Value indicating whether the checkbox is checked.
+	 */
+	public set checked(value: boolean) {
+		this.value = value;
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public override click(): void {
+		if (!this.disabled) {
+			this.checked = !this.checked;
+		}
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public override render(): TemplateResult {
+		return html`
+			<label
+				tabindex=${ifDefined(this.disabled ? undefined : 0)}
+				@keydown=${(ev: KeyboardEvent): void => {
+					// Toggle switch on space bar key.
+					if (ev.code === "Space") {
+						this.checked = !this.checked;
+						ev.preventDefault();
+					}
+				}}
+			>
+				<input
+					${ref(this.inputRef)}
+					type="checkbox"
+					.checked=${this.checked}
+					.disabled=${this.disabled}
+					@change=${(ev: HTMLInputEvent<HTMLInputElement>): void => {
+						this.checked = ev.target.checked;
+					}}
+				/>
+				<div class="checkbox" role="checkbox">
+					<svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" fill="currentColor" viewBox="0 0 24 24">
+						<path
+							d="M19.78 7.22a.75.75 0 0 1 0 1.06l-9.5 9.5a.75.75 0 0 1-1.06 0l-5-5a.75.75 0 1 1 1.06-1.06l4.47 4.47 8.97-8.97a.75.75 0 0 1 1.06 0Z"
+						/>
+					</svg>
+				</div>
+				${this.textContent && html`<span @mousedown=${preventDoubleClickSelection}>${this.textContent}</span>`}
+				<slot hidden @slotchange=${(): void => this.requestUpdate()}></slot>
+			</label>
+		`;
+	}
+}
+
+declare global {
+	interface HTMLElementTagNameMap {
+		/**
+		 * Element that offers a boolean option in the form of a checkbox.
+		 */
+		"sd-checkbox": SDCheckboxElement;
+	}
+}

--- a/src/ui/components/checkbox.ts
+++ b/src/ui/components/checkbox.ts
@@ -23,7 +23,6 @@ export class SDCheckboxElement extends Input(LitElement) {
 
 			label {
 				align-items: center;
-				display: flex;
 				display: inline-flex;
 				margin: var(--space-xs) 0;
 				outline: none;
@@ -40,7 +39,7 @@ export class SDCheckboxElement extends Input(LitElement) {
 			}
 
 			/**
-             * Checkbox and label
+             * Checkbox and text
              */
 
 			.checkbox {
@@ -57,12 +56,12 @@ export class SDCheckboxElement extends Input(LitElement) {
 				visibility: hidden;
 			}
 
-			span {
+			.text {
 				margin-right: var(--space-xs);
 			}
 
 			/**
-             * Input and states
+             * States
              */
 
 			input {
@@ -72,26 +71,23 @@ export class SDCheckboxElement extends Input(LitElement) {
 				&:checked + .checkbox {
 					border-width: 0;
 					background-color: var(--color-surface-accent);
+					color: var(--color-content-ondark);
 
 					& > svg {
-						color: var(--color-content-ondark);
-						visibility: visible;
-					}
-				}
-
-				/* Checked and disabled */
-				&:checked:disabled + .checkbox {
-					background-color: var(--color-surface-disabled);
-
-					& > svg {
-						color: var(--color-content-disabled);
 						visibility: visible;
 					}
 				}
 
 				/* Disabled */
-				&:disabled + .checkbox {
-					border-color: var(--color-border-subtle-disabled);
+				&:disabled {
+					& + .checkbox {
+						border-color: var(--color-border-subtle-disabled);
+					}
+
+					&:checked + .checkbox {
+						background-color: var(--color-surface-disabled);
+						color: var(--color-content-disabled);
+					}
 				}
 			}
 		`,
@@ -154,6 +150,7 @@ export class SDCheckboxElement extends Input(LitElement) {
 						this.checked = ev.target.checked;
 					}}
 				/>
+
 				<div class="checkbox" role="checkbox">
 					<svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" fill="currentColor" viewBox="0 0 24 24">
 						<path
@@ -161,7 +158,9 @@ export class SDCheckboxElement extends Input(LitElement) {
 						/>
 					</svg>
 				</div>
-				${this.textContent && html`<span @mousedown=${preventDoubleClickSelection}>${this.textContent}</span>`}
+
+				${this.textContent &&
+				html`<span class="text" @mousedown=${preventDoubleClickSelection}>${this.textContent}</span>`}
 				<slot hidden @slotchange=${(): void => this.requestUpdate()}></slot>
 			</label>
 		`;

--- a/src/ui/components/checkbox.ts
+++ b/src/ui/components/checkbox.ts
@@ -151,6 +151,7 @@ export class SDCheckboxElement extends Input(LitElement) {
 					.disabled=${this.disabled}
 					@change=${(ev: HTMLInputEvent<HTMLInputElement>): void => {
 						this.checked = ev.target.checked;
+						this.dispatchEvent(new Event("change")); // TODO: relocate this to Input for closed shadow roots
 					}}
 				/>
 

--- a/src/ui/components/checkbox.ts
+++ b/src/ui/components/checkbox.ts
@@ -98,6 +98,14 @@ export class SDCheckboxElement extends Input(LitElement) {
 	];
 
 	/**
+	 * Initializes a new instance of the {@link SDCheckboxElement} class.
+	 */
+	constructor() {
+		super();
+		this.role = "checkbox";
+	}
+
+	/**
 	 * Gets the checked state.
 	 * @returns `true` when the checkbox is checked; otherwise `false`.
 	 */

--- a/src/ui/components/checkbox.ts
+++ b/src/ui/components/checkbox.ts
@@ -4,13 +4,14 @@ import { ifDefined } from "lit/directives/if-defined.js";
 import { ref } from "lit/directives/ref.js";
 
 import { Input } from "../mixins/input";
+import { Labeled } from "../mixins/labeled";
 import { type HTMLInputEvent, preventDoubleClickSelection } from "../utils";
 
 /**
  * Element that offers persisting a `boolean` via a checkbox.
  */
 @customElement("sd-checkbox")
-export class SDCheckboxElement extends Input(LitElement) {
+export class SDCheckboxElement extends Labeled(Input(LitElement)) {
 	/**
 	 * @inheritdoc
 	 */
@@ -136,6 +137,7 @@ export class SDCheckboxElement extends Input(LitElement) {
 		return html`
 			<label
 				tabindex=${ifDefined(this.disabled ? undefined : 0)}
+				@mousedown=${preventDoubleClickSelection}
 				@keydown=${(ev: KeyboardEvent): void => {
 					// Toggle switch on space bar key.
 					if (ev.code === "Space") {
@@ -163,9 +165,7 @@ export class SDCheckboxElement extends Input(LitElement) {
 					</svg>
 				</div>
 
-				${this.textContent &&
-				html`<span class="text" @mousedown=${preventDoubleClickSelection}>${this.textContent}</span>`}
-				<slot hidden @slotchange=${(): void => this.requestUpdate()}></slot>
+				${this.label && html`<span class="text">${this.label}</span>`}
 			</label>
 		`;
 	}

--- a/src/ui/components/checkbox.ts
+++ b/src/ui/components/checkbox.ts
@@ -18,13 +18,17 @@ export class SDCheckboxElement extends Input(LitElement) {
 		super.styles ?? [],
 		css`
 			/**
-			 * Container
-			 */
+			* Container
+			*/
+
+			:host {
+				display: inline-flex;
+				margin: var(--space-xs) 0;
+			}
 
 			label {
 				align-items: center;
 				display: inline-flex;
-				margin: var(--space-xs) 0;
 				outline: none;
 
 				&:focus-visible .checkbox {
@@ -47,7 +51,6 @@ export class SDCheckboxElement extends Input(LitElement) {
 				border-radius: var(--rounding-m);
 				box-sizing: border-box;
 				height: var(--size-m);
-				margin-right: var(--space-xs);
 				width: var(--size-m);
 				user-select: none;
 			}
@@ -57,7 +60,7 @@ export class SDCheckboxElement extends Input(LitElement) {
 			}
 
 			.text {
-				margin-right: var(--space-xs);
+				margin-left: var(--space-xs);
 			}
 
 			/**

--- a/src/ui/components/checkbox.ts
+++ b/src/ui/components/checkbox.ts
@@ -23,12 +23,12 @@ export class SDCheckboxElement extends Input(LitElement) {
 
 			:host {
 				display: inline-flex;
-				margin: var(--space-xs) 0;
 			}
 
 			label {
 				align-items: center;
 				display: inline-flex;
+				margin: var(--space-xs) 0;
 				outline: none;
 
 				&:focus-visible .checkbox {

--- a/src/ui/components/index.ts
+++ b/src/ui/components/index.ts
@@ -1,4 +1,5 @@
 export * from "./button";
+export * from "./checkbox";
 export * from "./divider";
 export * from "./field";
 export * from "./label";

--- a/src/ui/components/index.ts
+++ b/src/ui/components/index.ts
@@ -1,5 +1,6 @@
 export * from "./button";
 export * from "./checkbox";
+export * from "./checkbox-group";
 export * from "./divider";
 export * from "./field";
 export * from "./label";

--- a/src/ui/components/option.ts
+++ b/src/ui/components/option.ts
@@ -2,12 +2,13 @@ import { LitElement } from "lit";
 import { customElement, property } from "lit/decorators.js";
 
 import { parseBoolean, parseNumber } from "../../common/utils";
+import { Labeled } from "../mixins/labeled";
 
 /**
  * Non-visual element that provides information for an option.
  */
 @customElement("sd-option")
-export class SDOptionElement extends LitElement {
+export class SDOptionElement extends Labeled(LitElement) {
 	/**
 	 * Private backing field for {@link SDOptionElement.value}.
 	 */
@@ -21,12 +22,6 @@ export class SDOptionElement extends LitElement {
 		type: Boolean,
 	})
 	public accessor disabled: boolean = false;
-
-	/**
-	 * Label that represents the option.
-	 */
-	@property()
-	public accessor label: string | undefined;
 
 	/**
 	 * Type of the value; allows for the value to be converted to a boolean or number.

--- a/src/ui/components/radio-group.ts
+++ b/src/ui/components/radio-group.ts
@@ -7,7 +7,7 @@ import { List } from "../mixins/list";
 import { SDRadioElement } from "./radio";
 
 /**
- * Element that offers persisting a value via a list of radio options.
+ * Element that offers persisting a `boolean`, `number`, or `string` from a list of radio options.
  */
 @customElement("sd-radiogroup")
 export class SDRadioGroupElement extends List(Input<boolean | number | string>(LitElement)) {
@@ -53,7 +53,7 @@ export class SDRadioGroupElement extends List(Input<boolean | number | string>(L
 declare global {
 	interface HTMLElementTagNameMap {
 		/**
-		 * Element that offers persisting a value via a list of radio options.
+		 * Element that offers persisting a `boolean`, `number`, or `string` from a list of radio options.
 		 */
 		"sd-radiogroup": SDRadioGroupElement;
 	}

--- a/src/ui/components/radio-group.ts
+++ b/src/ui/components/radio-group.ts
@@ -42,8 +42,7 @@ export class SDRadioGroupElement extends List(Input<boolean | number | string>(L
 						@change=${(): void => {
 							this.value = opt.value;
 						}}
-						>${opt.innerText}</sd-radio
-					>`;
+					/>`;
 				},
 			)}
 		`;

--- a/src/ui/components/radio.ts
+++ b/src/ui/components/radio.ts
@@ -126,11 +126,6 @@ export class SDRadioElement extends SDOptionElement {
 	public accessor checked: boolean = false;
 
 	/**
-	 * Fallback label, derived from the original inner text of this element when creating the render root.
-	 */
-	#fallbackLabel: string | undefined;
-
-	/**
 	 * @inheritdoc
 	 */
 	public override connectedCallback(): void {
@@ -173,8 +168,10 @@ export class SDRadioElement extends SDOptionElement {
 					.checked=${this.checked}
 					.disabled=${this.disabled}
 				/>
+
 				<span role="radio" aria-checked=${this.checked}></span>
-				${this.label ?? this.#fallbackLabel}
+
+				${this.label}
 			</label>
 		`;
 	}
@@ -184,9 +181,7 @@ export class SDRadioElement extends SDOptionElement {
 	 */
 	protected override createRenderRoot(): DocumentFragment | HTMLElement {
 		// Shadow root has to be open to allow for joining named radio buttons.
-		this.#fallbackLabel = this.innerText;
 		this.innerHTML = "";
-
 		return this;
 	}
 }

--- a/src/ui/components/switch.ts
+++ b/src/ui/components/switch.ts
@@ -23,12 +23,12 @@ export class SDSwitchElement extends Input<boolean>(LitElement) {
 
 			:host {
 				display: inline-flex;
-				margin: var(--space-xs) 0;
 			}
 
 			label {
 				align-items: center;
 				display: inline-flex;
+				margin: var(--space-xs) 0;
 				outline: none;
 
 				&:focus-visible .track {

--- a/src/ui/components/switch.ts
+++ b/src/ui/components/switch.ts
@@ -124,12 +124,6 @@ export class SDSwitchElement extends Input<boolean>(LitElement) {
 	}
 
 	/**
-	 * Label of the switch.
-	 */
-	@property()
-	public accessor label: string | undefined;
-
-	/**
 	 * @inheritdoc
 	 */
 	public override click(): void {
@@ -168,7 +162,8 @@ export class SDSwitchElement extends Input<boolean>(LitElement) {
 					<div class="track" role="button">
 						<div class="thumb"></div>
 					</div>
-					${this.label}
+					${this.textContent}
+					<slot hidden @slotchange=${(): void => this.requestUpdate()}></slot>
 				</div>
 			</sd-label>
 		`;

--- a/src/ui/components/switch.ts
+++ b/src/ui/components/switch.ts
@@ -4,7 +4,7 @@ import { ifDefined } from "lit/directives/if-defined.js";
 import { ref } from "lit/directives/ref.js";
 
 import { Input } from "../mixins/input";
-import type { HTMLInputEvent } from "../utils";
+import { type HTMLInputEvent, preventDoubleClickSelection } from "../utils";
 
 /**
  * Element that offers persisting a `boolean` via a toggle switch.
@@ -18,58 +18,38 @@ export class SDSwitchElement extends Input<boolean>(LitElement) {
 		super.styles ?? [],
 		css`
 			/**
-			 * Containers
+			 * Container
 			 */
 
-			sd-label {
-				outline: none;
-			}
-
-			.container {
+			label {
 				align-items: center;
 				display: inline-flex;
-			}
+				margin: var(--space-xs) 0;
+				outline: none;
 
-			input {
-				display: none;
+				&:focus-visible .track {
+					box-shadow: var(--highlight-box-shadow);
+					outline: var(--highlight-outline--focus);
+					outline-offset: var(--highlight-outline-offset);
+				}
 			}
 
 			/**
-             * Track
+             * Track, thumb, and text
              */
 
 			.track {
 				align-items: center;
 				background: var(--color-surface-strong);
 				border-radius: var(--rounding-full);
-				cursor: pointer;
 				display: inline-flex;
-				margin: var(--space-xs) var(--space-xs) var(--space-xs) 0;
+				margin-right: var(--space-xs);
 				padding: 0px var(--space-3xs);
 				transition: 0.2;
 				height: var(--size-m);
 				width: var(--size-xl);
 				user-select: none;
 			}
-
-			sd-label[aria-disabled="false"]:has(input:checked) .track {
-				background: var(--color-surface-accent);
-			}
-
-			sd-label[aria-disabled="true"] .track {
-				background: var(--color-surface-disabled);
-				cursor: default;
-			}
-
-			sd-label:focus-visible .track {
-				box-shadow: var(--highlight-box-shadow);
-				outline: var(--highlight-outline--focus);
-				outline-offset: var(--highlight-outline-offset);
-			}
-
-			/**
-             * Thumb
-             */
 
 			.thumb {
 				background: var(--color-content-primary);
@@ -80,16 +60,44 @@ export class SDSwitchElement extends Input<boolean>(LitElement) {
 				width: var(--size-s);
 			}
 
-			sd-label:has(input:checked) .thumb {
-				transform: translateX(100%);
+			.text {
+				margin-right: var(--space-xs);
 			}
 
-			sd-label[aria-disabled="false"] .thumb {
-				background: var(--color-surface-ondark);
-			}
+			/**
+			 * States
+			 */
 
-			sd-label[aria-disabled="true"] .thumb {
-				background: var(--color-surface-strong);
+			input {
+				display: none;
+
+				/* Checked */
+				&:checked {
+					& + .track .thumb {
+						transform: translateX(100%);
+					}
+
+					&:not(:disabled) {
+						& + .track {
+							background: var(--color-surface-accent);
+						}
+
+						& + .track .thumb {
+							background: var(--color-surface-ondark);
+						}
+					}
+				}
+
+				/* Disabled */
+				&:disabled {
+					& + .track {
+						background: var(--color-surface-disabled);
+					}
+
+					& + .track .thumb {
+						background: var(--color-surface-strong);
+					}
+				}
 			}
 		`,
 	];
@@ -99,7 +107,6 @@ export class SDSwitchElement extends Input<boolean>(LitElement) {
 	 */
 	constructor() {
 		super();
-
 		this.role = "checkbox";
 	}
 
@@ -137,8 +144,7 @@ export class SDSwitchElement extends Input<boolean>(LitElement) {
 	 */
 	public override render(): TemplateResult {
 		return html`
-			<sd-label
-				aria-disabled=${this.disabled}
+			<label
 				tabindex=${ifDefined(this.disabled ? undefined : 0)}
 				@keydown=${(ev: KeyboardEvent): void => {
 					// Toggle switch on space bar key.
@@ -158,14 +164,15 @@ export class SDSwitchElement extends Input<boolean>(LitElement) {
 						this.isOn = ev.target.checked;
 					}}
 				/>
-				<div class="container">
-					<div class="track" role="button">
-						<div class="thumb"></div>
-					</div>
-					${this.textContent}
-					<slot hidden @slotchange=${(): void => this.requestUpdate()}></slot>
+
+				<div class="track" role="button">
+					<div class="thumb"></div>
 				</div>
-			</sd-label>
+
+				${this.textContent &&
+				html`<span class="text" @mousedown=${preventDoubleClickSelection}>${this.textContent}</span>`}
+				<slot hidden @slotchange=${(): void => this.requestUpdate()}></slot>
+			</label>
 		`;
 	}
 

--- a/src/ui/components/switch.ts
+++ b/src/ui/components/switch.ts
@@ -21,10 +21,14 @@ export class SDSwitchElement extends Input<boolean>(LitElement) {
 			 * Container
 			 */
 
+			:host {
+				display: inline-flex;
+				margin: var(--space-xs) 0;
+			}
+
 			label {
 				align-items: center;
 				display: inline-flex;
-				margin: var(--space-xs) 0;
 				outline: none;
 
 				&:focus-visible .track {
@@ -43,7 +47,6 @@ export class SDSwitchElement extends Input<boolean>(LitElement) {
 				background: var(--color-surface-strong);
 				border-radius: var(--rounding-full);
 				display: inline-flex;
-				margin-right: var(--space-xs);
 				padding: 0px var(--space-3xs);
 				transition: 0.2;
 				height: var(--size-m);
@@ -61,7 +64,7 @@ export class SDSwitchElement extends Input<boolean>(LitElement) {
 			}
 
 			.text {
-				margin-right: var(--space-xs);
+				margin-left: var(--space-xs);
 			}
 
 			/**

--- a/src/ui/components/switch.ts
+++ b/src/ui/components/switch.ts
@@ -4,13 +4,14 @@ import { ifDefined } from "lit/directives/if-defined.js";
 import { ref } from "lit/directives/ref.js";
 
 import { Input } from "../mixins/input";
+import { Labeled } from "../mixins/labeled";
 import { type HTMLInputEvent, preventDoubleClickSelection } from "../utils";
 
 /**
  * Element that offers persisting a `boolean` via a toggle switch.
  */
 @customElement("sd-switch")
-export class SDSwitchElement extends Input<boolean>(LitElement) {
+export class SDSwitchElement extends Labeled(Input<boolean>(LitElement)) {
 	/**
 	 * @inheritdoc
 	 */
@@ -149,6 +150,7 @@ export class SDSwitchElement extends Input<boolean>(LitElement) {
 		return html`
 			<label
 				tabindex=${ifDefined(this.disabled ? undefined : 0)}
+				@mousedown=${preventDoubleClickSelection}
 				@keydown=${(ev: KeyboardEvent): void => {
 					// Toggle switch on space bar key.
 					if (ev.code === "Space") {
@@ -172,9 +174,7 @@ export class SDSwitchElement extends Input<boolean>(LitElement) {
 					<div class="thumb"></div>
 				</div>
 
-				${this.textContent &&
-				html`<span class="text" @mousedown=${preventDoubleClickSelection}>${this.textContent}</span>`}
-				<slot hidden @slotchange=${(): void => this.requestUpdate()}></slot>
+				${this.label && html`<span class="text">${this.label}</span>`}
 			</label>
 		`;
 	}

--- a/src/ui/mixins/labeled.ts
+++ b/src/ui/mixins/labeled.ts
@@ -1,0 +1,63 @@
+import { LitElement } from "lit";
+import { property } from "lit/decorators.js";
+
+import type { Constructor } from "../../common/utils";
+
+/**
+ * Labeled mixin that provides a reactive `label` property, attached to the `textContent`.
+ * @param superClass Class the mixin extends.
+ * @returns Labeled mixin class.
+ */
+export const Labeled = <TBase extends Constructor<LitElement> = typeof LitElement>(
+	superClass: TBase,
+): Constructor<SDLabeledElement> & TBase => {
+	/**
+	 * Labeled mixin that provides a reactive `label` property, attached to the `textContent`.
+	 */
+	class LabeledMixin extends superClass {
+		/**
+		 * Observer for monitoring the `textContent` changing.
+		 */
+		#textContentObserver = new MutationObserver((): void => {
+			this.label = this.textContent?.trim();
+		});
+
+		/**
+		 * @inheritdoc
+		 */
+		@property({ attribute: false })
+		public accessor label: string | undefined = this.textContent?.trim();
+
+		/**
+		 * @inheritdoc
+		 */
+		public override connectedCallback(): void {
+			super.connectedCallback();
+
+			this.#textContentObserver.observe(this, {
+				childList: true,
+				subtree: true,
+			});
+		}
+
+		/**
+		 * @inheritdoc
+		 */
+		public override disconnectedCallback(): void {
+			super.disconnectedCallback();
+			this.#textContentObserver.disconnect();
+		}
+	}
+
+	return LabeledMixin as unknown as Constructor<SDLabeledElement> & TBase;
+};
+
+/**
+ * Labeled mixin that provides a reactive `label` property, attached to the `textContent`.
+ */
+export declare class SDLabeledElement extends LitElement {
+	/**
+	 * Label of the element.
+	 */
+	public label: string | undefined;
+}


### PR DESCRIPTION
- Adds `<sd-checkbox />`.
- Adds `<sd-checkboxgroup />`.
- Fixes incorrect activation space around `<sd-switch />`.
- Updates `<sd-switch />` to be read from `textContent`, rather than `label`.
- Updates `<sd-switch />` styles to align with `<sd-checkbox />`.
- Removes `<sd-label />` from `<sd-switch />`.