### PR TITLE
feat: add placeholder and label-setting

### DIFF
--- a/src/ui/components/select.ts
+++ b/src/ui/components/select.ts
@@ -1,5 +1,5 @@
 import { css, type CSSResult, html, LitElement, type TemplateResult, unsafeCSS } from "lit";
-import { customElement, property } from "lit/decorators.js";
+import { customElement, property, state } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { ref } from "lit/directives/ref.js";
 
@@ -7,7 +7,10 @@ import { parseBoolean, parseNumber } from "../../common/utils";
 import { OptionObserver } from "../controllers/option-observer";
 import { Input } from "../mixins/input";
 import { Persistable } from "../mixins/persistable";
+import { useGlobalSetting, useSetting } from "../settings";
+import type { SettingSignal, SettingSignalOptions } from "../settings/signals";
 import type { HTMLEvent } from "../utils";
+import { watch } from "../utils/watch";
 
 /**
  * Gets a chevron with the specified fill color.
@@ -73,6 +76,26 @@ export class SDSelectElement extends Input(Persistable<boolean | number | string
 	public accessor placeholder: string | undefined;
 
 	/**
+	 * Path to the setting where the selected option's label will be persisted.
+	 *
+	 * In the event a previously selected option is no longer available, the label stored at this setting
+	 * will be rendered as an unselectable option within the select.
+	 */
+	@property({ attribute: "label-setting" })
+	public accessor labelSetting: string | undefined;
+
+	/**
+	 * Label of the (previously) selected option.
+	 */
+	@state()
+	accessor #label: string | undefined;
+
+	/**
+	 * Signal used to persist and access the label of the (previously) selected option.
+	 */
+	#labelSignal: SettingSignal<string> | undefined;
+
+	/**
 	 * Controller responsible for monitoring the slotted options.
 	 */
 	#options: OptionObserver;
@@ -97,10 +120,13 @@ export class SDSelectElement extends Input(Persistable<boolean | number | string
 					const selected = ev.target[ev.target.selectedIndex];
 					if (selected instanceof HTMLOptionElement) {
 						this.value = this.#parseValue(selected);
+						this.#labelSignal?.value?.set(selected.label);
 					}
 				}}
 			>
-				<option disabled hidden selected>${this.placeholder ?? ""}</option>
+				<option disabled hidden selected>
+					${this.value === undefined ? (this.placeholder ?? "") : (this.#label ?? this.placeholder ?? "")}
+				</option>
 				${this.#options.dataList.map(
 					(opt) =>
 						html`<option
@@ -116,6 +142,26 @@ export class SDSelectElement extends Input(Persistable<boolean | number | string
 				)}
 			</select>
 		`;
+	}
+
+	/**
+	 * Manages the settings signal used to persisted the label of the selected option.
+	 */
+	@watch(["labelSetting", "global"])
+	protected labelSettingWillUpdate(): void {
+		this.#labelSignal?.dispose();
+
+		if (this.labelSetting) {
+			const options: SettingSignalOptions<string> = {
+				onChange: (value: string | undefined) => (this.#label = value),
+			};
+
+			this.#labelSignal = this.global
+				? useGlobalSetting(this.labelSetting, options)
+				: useSetting(this.labelSetting, options);
+
+			this.#labelSignal.value.get().then(options.onChange);
+		}
 	}
 
 	/**

--- a/src/ui/components/select.ts
+++ b/src/ui/components/select.ts
@@ -1,5 +1,5 @@
 import { css, type CSSResult, html, LitElement, type TemplateResult, unsafeCSS } from "lit";
-import { customElement } from "lit/decorators.js";
+import { customElement, property } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { ref } from "lit/directives/ref.js";
 
@@ -67,6 +67,12 @@ export class SDSelectElement extends Input(Persistable<boolean | number | string
 	];
 
 	/**
+	 * Placeholder to be shown when an option has not yet been selected.
+	 */
+	@property()
+	public accessor placeholder: string | undefined;
+
+	/**
 	 * Controller responsible for monitoring the slotted options.
 	 */
 	#options: OptionObserver;
@@ -94,6 +100,7 @@ export class SDSelectElement extends Input(Persistable<boolean | number | string
 					}
 				}}
 			>
+				<option disabled hidden selected>${this.placeholder ?? ""}</option>
 				${this.#options.dataList.map(
 					(opt) =>
 						html`<option

--- a/src/ui/components/select.ts
+++ b/src/ui/components/select.ts
@@ -52,8 +52,8 @@ export class SDSelectElement extends Input(Persistable<boolean | number | string
 				font-family: var(--typography-body-m-family);
 				font-size: var(--typography-body-m-size);
 				font-weight: var(--typography-body-m-weight);
-				max-width: 100%;
 				padding: 0 calc(var(--space-xs) + var(--space-xs) + var(--size-m)) 0 var(--space-xs);
+				width: 100%;
 
 				&:disabled {
 					color: var(--color-content-disabled);

--- a/src/ui/utils/watch.ts
+++ b/src/ui/utils/watch.ts
@@ -1,0 +1,44 @@
+import type { LitElement, ReactiveElement } from "lit";
+
+/**
+ * Invokes the decorated function when one of the properties' values changes.
+ * @param propertyName Name of the properties to watch.
+ * @returns The original function.
+ */
+export function watch<T extends () => void>(
+	propertyName: string[] | string,
+): (fn: T, context: ClassMethodDecoratorContext<LitElement>) => T {
+	const watchedProperties = Array.isArray(propertyName) ? propertyName : [propertyName];
+
+	return (fn: T, context: ClassMethodDecoratorContext<LitElement>): T => {
+		context.addInitializer(function () {
+			const elem = this as unknown as LitElement & UnprotectedReactiveElement;
+			const { willUpdate } = elem;
+
+			// Update the original `willUpdate`.
+			elem.willUpdate = function (_changedProperties: Map<PropertyKey, unknown>): void {
+				willUpdate.call(this, _changedProperties);
+
+				// Check if the one of the watch properties has changed.
+				for (const key of watchedProperties) {
+					if (_changedProperties.has(key)) {
+						fn.call(this);
+						return;
+					}
+				}
+			};
+		});
+
+		return fn;
+	};
+}
+
+/**
+ * Utility type for {@link ReactiveElement} that updates the visibility of methods for mutation.
+ */
+type UnprotectedReactiveElement = ReactiveElement & {
+	/**
+	 * See {@link ReactiveElement.willUpdate}.
+	 */
+	willUpdate(_changedProperties: Map<PropertyKey, unknown>): void;
+};


### PR DESCRIPTION
- Adds `placeholder`, an unselectable value shown within the select.
- Adds `label-setting`, the path to the setting of where the selected option's label will be saved. Persisting the label allows for the option to be shown, even if removed in subsequent renders.