### PR TITLE
refactor!: remove dependency on reading the manifest

### DIFF
--- a/src/plugin/__tests__/index.test.ts
+++ b/src/plugin/__tests__/index.test.ts
@@ -29,7 +29,6 @@ describe("index", () => {
 		// Arrange.
 		const { actionService } = await require("../actions/service");
 		const { deviceService } = await require("../devices/service");
-		const { getManifest } = await require("../manifest");
 		const profiles = await require("../profiles");
 		const settings = await require("../settings");
 		const system = await require("../system");
@@ -38,7 +37,6 @@ describe("index", () => {
 		// Act, assert.
 		expect(streamDeck.actions).toBe(actionService);
 		expect(streamDeck.devices).toBe(deviceService);
-		expect(streamDeck.manifest).toBe(getManifest());
 		expect(streamDeck.profiles).toBe(profiles);
 		expect(streamDeck.settings).toBe(settings);
 		expect(streamDeck.system).toBe(system);

--- a/src/plugin/__tests__/manifest.test.ts
+++ b/src/plugin/__tests__/manifest.test.ts
@@ -83,7 +83,7 @@ describe("manifest", () => {
 		it("returns null when the manifest cannot be read", () => {
 			// Arrange.
 			jest.spyOn(fs, "existsSync").mockReturnValue(true);
-			const readSpy = jest.spyOn(fs, "readFileSync").mockReturnValueOnce("_");
+			jest.spyOn(fs, "readFileSync").mockReturnValueOnce("_");
 
 			// Act, assert.
 			expect(getSoftwareMinimumVersion()).toEqual(null);

--- a/src/plugin/__tests__/manifest.test.ts
+++ b/src/plugin/__tests__/manifest.test.ts
@@ -12,7 +12,7 @@ describe("manifest", () => {
 	afterEach(() => jest.resetModules());
 
 	describe("getManifest", () => {
-		it("Errors when file does not exist", () => {
+		it("errors when file does not exist", () => {
 			// Arrange.
 			const existsSync = jest.spyOn(fs, "existsSync").mockReturnValueOnce(false);
 			jest.spyOn(process, "cwd").mockReturnValueOnce("test");
@@ -23,7 +23,7 @@ describe("manifest", () => {
 			expect(existsSync).toHaveBeenCalledWith(path.join("test", "manifest.json"));
 		});
 
-		it("Parses the manifest file", () => {
+		it("parses the manifest file", () => {
 			// Arrange.
 			jest.spyOn(fs, "existsSync").mockReturnValue(true);
 			jest.spyOn(fs, "readFileSync").mockReturnValueOnce(JSON.stringify(mockManifest));
@@ -35,16 +35,16 @@ describe("manifest", () => {
 			expect(manifest).toEqual(mockManifest);
 		});
 
-		it("Errors when the manifest cannot be parsed", () => {
+		it("returns null when the manifest cannot be parsed", () => {
 			// Arrange.
 			jest.spyOn(fs, "existsSync").mockReturnValueOnce(true);
 			jest.spyOn(fs, "readFileSync").mockReturnValueOnce("_");
 
 			// Act, assert.
-			expect(getManifest).toThrowError("Unexpected token '_', \"_\" is not valid JSON");
+			expect(getManifest()).toEqual(null);
 		});
 
-		it("Caches the result", () => {
+		it("caches the result", () => {
 			// Arrange.
 			jest.spyOn(fs, "existsSync").mockReturnValue(true);
 			const readSpy = jest.spyOn(fs, "readFileSync").mockReturnValueOnce(JSON.stringify(mockManifest));
@@ -60,7 +60,7 @@ describe("manifest", () => {
 	});
 
 	describe("getSoftwareMinimumVersion", () => {
-		it("Reads the minimum version from the manifest", () => {
+		it("reads the minimum version from the manifest", () => {
 			// Arrange.
 			jest.spyOn(fs, "existsSync").mockReturnValue(true);
 			const readSpy = jest.spyOn(fs, "readFileSync").mockReturnValueOnce(
@@ -75,12 +75,21 @@ describe("manifest", () => {
 			const version = getSoftwareMinimumVersion();
 
 			// Assert.
-			expect(version.major).toEqual(6);
-			expect(version.minor).toEqual(5);
+			expect(version!.major).toEqual(6);
+			expect(version!.minor).toEqual(5);
 			expect(readSpy).toBeCalledTimes(1);
 		});
 
-		it("Caches the result", () => {
+		it("returns null when the manifest cannot be read", () => {
+			// Arrange.
+			jest.spyOn(fs, "existsSync").mockReturnValue(true);
+			const readSpy = jest.spyOn(fs, "readFileSync").mockReturnValueOnce("_");
+
+			// Act, assert.
+			expect(getSoftwareMinimumVersion()).toEqual(null);
+		});
+
+		it("caches the result", () => {
 			// Arrange.
 			jest.spyOn(fs, "existsSync").mockReturnValue(true);
 			const readSpy = jest.spyOn(fs, "readFileSync").mockReturnValueOnce(JSON.stringify(mockManifest));

--- a/src/plugin/actions/service.ts
+++ b/src/plugin/actions/service.ts
@@ -36,7 +36,7 @@ import { KeyAction } from "./key";
 import type { SingletonAction } from "./singleton-action";
 import { actionStore, ReadOnlyActionStore } from "./store";
 
-const manifest = new Lazy<Manifest>(() => getManifest());
+const manifest = new Lazy<Manifest | null>(() => getManifest());
 
 /**
  * Provides functions, and information, for interacting with Stream Deck actions.
@@ -216,7 +216,7 @@ class ActionService extends ReadOnlyActionStore {
 			throw new Error("The action's manifestId cannot be undefined.");
 		}
 
-		if (!manifest.value.Actions.some((a) => a.UUID === action.manifestId)) {
+		if (manifest.value !== null && !manifest.value.Actions.some((a) => a.UUID === action.manifestId)) {
 			throw new Error(`The action's manifestId was not found within the manifest: ${action.manifestId}`);
 		}
 

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -1,4 +1,4 @@
-import type { Manifest, RegistrationInfo } from "../api";
+import type { RegistrationInfo } from "../api";
 import { I18nProvider } from "../common/i18n";
 import { type Logger, registerCreateLogEntryRoute } from "../common/logging";
 import { actionService, type ActionService } from "./actions/service";
@@ -6,7 +6,6 @@ import { connection } from "./connection";
 import { deviceService, type DeviceService } from "./devices/service";
 import { fileSystemLocaleProvider } from "./i18n";
 import { logger } from "./logging";
-import { getManifest } from "./manifest";
 import * as profiles from "./profiles";
 import * as settings from "./settings";
 import * as system from "./system";
@@ -89,14 +88,6 @@ export const streamDeck = {
 	 */
 	get logger(): Logger {
 		return logger;
-	},
-
-	/**
-	 * Manifest associated with the plugin, as defined within the `manifest.json` file.
-	 * @returns The manifest.
-	 */
-	get manifest(): Manifest {
-		return getManifest();
 	},
 
 	/**

--- a/src/plugin/manifest.ts
+++ b/src/plugin/manifest.ts
@@ -36,8 +36,8 @@ const softwareMinimumVersion = new Lazy<Version | null>(() => {
 });
 
 /**
- * Gets the minimum version that this plugin required, as defined within the manifest.
- * @returns Minimum required version; or `null` when the plugin is DRM protected.
+ * Gets the minimum version that the plugin requires.
+ * @returns Minimum required version; otherwise `null` when the plugin is DRM protected.
  */
 export function getSoftwareMinimumVersion(): Version | null {
 	return softwareMinimumVersion.value;
@@ -45,7 +45,7 @@ export function getSoftwareMinimumVersion(): Version | null {
 
 /**
  * Gets the manifest associated with the plugin.
- * @returns The manifest; or `null` when the plugin is DRM protected.
+ * @returns The manifest; otherwise `null` when the plugin is DRM protected.
  */
 export function getManifest(): Manifest | null {
 	return manifest.value;

--- a/src/plugin/manifest.ts
+++ b/src/plugin/manifest.ts
@@ -2,41 +2,51 @@ import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { Manifest } from "../api";
+import { Lazy } from "../common/lazy";
 import { Version } from "./common/version";
 
-let manifest: Manifest;
-let softwareMinimumVersion: Version;
-
-/**
- * Gets the minimum version that this plugin required, as defined within the manifest.
- * @returns Minimum required version.
- */
-export function getSoftwareMinimumVersion(): Version {
-	return (softwareMinimumVersion ??= new Version(getManifest().Software.MinimumVersion));
-}
-
-/**
- * Gets the manifest associated with the plugin.
- * @returns The manifest.
- */
-export function getManifest(): Manifest {
-	return (manifest ??= readManifest());
-}
-
-/**
- * Reads the manifest associated with the plugin from the `manifest.json` file.
- * @returns The manifest.
- */
-function readManifest(): Manifest {
+const manifest = new Lazy<Manifest | null>(() => {
 	const path = join(process.cwd(), "manifest.json");
 	if (!existsSync(path)) {
 		throw new Error("Failed to read manifest.json as the file does not exist.");
 	}
 
-	return JSON.parse(
-		readFileSync(path, {
-			encoding: "utf-8",
-			flag: "r",
-		}).toString(),
-	);
+	try {
+		return JSON.parse(
+			readFileSync(path, {
+				encoding: "utf-8",
+				flag: "r",
+			}).toString(),
+		);
+	} catch (e) {
+		if (e instanceof SyntaxError) {
+			return null;
+		} else {
+			throw e;
+		}
+	}
+});
+
+const softwareMinimumVersion = new Lazy<Version | null>(() => {
+	if (manifest.value === null) {
+		return null;
+	}
+
+	return new Version(manifest.value.Software.MinimumVersion);
+});
+
+/**
+ * Gets the minimum version that this plugin required, as defined within the manifest.
+ * @returns Minimum required version; or `null` when the plugin is DRM protected.
+ */
+export function getSoftwareMinimumVersion(): Version | null {
+	return softwareMinimumVersion.value;
+}
+
+/**
+ * Gets the manifest associated with the plugin.
+ * @returns The manifest; or `null` when the plugin is DRM protected.
+ */
+export function getManifest(): Manifest | null {
+	return manifest.value;
 }

--- a/src/plugin/validation.ts
+++ b/src/plugin/validation.ts
@@ -2,8 +2,8 @@ import { Version } from "./common/version";
 import { getSoftwareMinimumVersion } from "./manifest";
 
 /**
- * Validates the {@link streamDeckVersion} and manifest's `Software.MinimumVersion` are at least the {@link minimumVersion}; when the version is not fulfilled, an error is thrown with the
- * {@link feature} formatted into the message.
+ * Validates the {@link streamDeckVersion} and manifest's `Software.MinimumVersion` are at least the {@link minimumVersion};
+ * when the version is not fulfilled, an error is thrown with the {@link feature} formatted into the message.
  * @param minimumVersion Minimum required version.
  * @param streamDeckVersion Actual application version.
  * @param feature Feature that requires the version.

--- a/src/plugin/validation.ts
+++ b/src/plugin/validation.ts
@@ -20,7 +20,10 @@ export function requiresVersion(minimumVersion: number, streamDeckVersion: Versi
 		throw new Error(
 			`[ERR_NOT_SUPPORTED]: ${feature} requires Stream Deck version ${required.major}.${required.minor} or higher, but current version is ${streamDeckVersion.major}.${streamDeckVersion.minor}; please update Stream Deck and the "Software.MinimumVersion" in the plugin's manifest to "${required.major}.${required.minor}" or higher.`,
 		);
-	} else if (getSoftwareMinimumVersion().compareTo(required) === -1) {
+	}
+
+	const softwareMinimumVersion = getSoftwareMinimumVersion();
+	if (softwareMinimumVersion !== null && softwareMinimumVersion.compareTo(required) === -1) {
 		throw new Error(
 			`[ERR_NOT_SUPPORTED]: ${feature} requires Stream Deck version ${required.major}.${required.minor} or higher; please update the "Software.MinimumVersion" in the plugin's manifest to "${required.major}.${required.minor}" or higher.`,
 		);


### PR DESCRIPTION
- Update manifest to be nullable.
- Remove `manifest` from main export.
- Update action service to evaluate UUID exists only in development.
- Update minimum required version checks to only occur in development.