### PR TITLE
feat: add SDK version check to secrets API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@
 
 # Change Log
 
+## 2.0.0-alpha.2
+
+### ✨ New
+
+- Add `streamDeck.devices.onDidChange` event; occurs when a device name or size changes.
+
 ## 2.0.0-alpha.1
 
 This release focuses on relocating the property inspector functionality to a dedicated `@streamdeck/ui` module.

--- a/src/api/events/index.ts
+++ b/src/api/events/index.ts
@@ -8,6 +8,7 @@ import type {
 	ApplicationDidTerminate,
 	DidReceiveDeepLink,
 	DidReceiveGlobalSettings,
+	DidReceiveSecrets,
 	SystemDidWakeUp,
 } from "./system";
 import type {
@@ -68,6 +69,7 @@ export type PluginEvent =
 	| DidReceiveDeepLink
 	| DidReceiveGlobalSettings<JsonObject>
 	| DidReceivePropertyInspectorMessage<JsonValue>
+	| DidReceiveSecrets<JsonObject>
 	| DidReceiveSettings<JsonObject>
 	| KeyDown<JsonObject>
 	| KeyUp<JsonObject>

--- a/src/plugin/__mocks__/manifest.ts
+++ b/src/plugin/__mocks__/manifest.ts
@@ -51,6 +51,11 @@ export const manifest: Manifest = {
 };
 
 /**
+ * Mocked `getSDKVersion`.
+ */
+export const getSDKVersion = jest.fn().mockReturnValue(3);
+
+/**
  * Mocked {@link __getSoftwareMinimumVersion}.
  */
 export const getSoftwareMinimumVersion = jest.fn().mockReturnValue(new Version("7.0"));

--- a/src/plugin/__tests__/system.test.ts
+++ b/src/plugin/__tests__/system.test.ts
@@ -14,6 +14,7 @@ import {
 	DidReceiveDeepLinkEvent,
 	SystemDidWakeUpEvent,
 } from "../events";
+import * as manifest from "../manifest";
 import {
 	getSecrets,
 	onApplicationDidLaunch,
@@ -190,33 +191,60 @@ describe("system", () => {
 		});
 	});
 
-	it("getSecrets", async () => {
-		// Arrange, act (Command).
-		const secrets = getSecrets<Secrets>();
+	describe("getSecrets", () => {
+		it("requires SDKVersion 3 or higher", () => {
+			// Arrange.
+			jest.spyOn(manifest, "getSDKVersion").mockReturnValue(2); // Not okay
+			jest.spyOn(manifest, "getSoftwareMinimumVersion").mockReturnValue(new Version("6.9")); // Okay
 
-		// Assert (Command).
-		expect(connection.send).toHaveBeenCalledTimes(1);
-		expect(connection.send).toHaveBeenLastCalledWith({
-			event: "getSecrets",
-			context: connection.registrationParameters.pluginUUID,
+			// Act, assert.
+			expect(() => getSecrets()).toThrow(
+				`[ERR_NOT_SUPPORTED]: Secrets requires manifest SDK version 3 or higher, but found version 2; please update the "SDKVersion" in the plugin's manifest to 3 or higher.`,
+			);
 		});
 
-		expect(Promise.race([secrets, false])).resolves.toBe(false);
+		it("requires Software.MinimumVersion 6.9 or higher", () => {
+			// Arrange.
+			jest.spyOn(manifest, "getSDKVersion").mockReturnValue(3); // Okay
+			jest.spyOn(manifest, "getSoftwareMinimumVersion").mockReturnValue(new Version("6.8")); // Not okay
 
-		// Act (Event).
-		connection.emit("didReceiveSecrets", {
-			event: "didReceiveSecrets",
-			payload: {
-				secrets: {
-					secret: "Elgato",
+			// Act, assert.
+			expect(() => getSecrets()).toThrow(
+				`[ERR_NOT_SUPPORTED]: Secrets requires Stream Deck version 6.9 or higher; please update the "Software.MinimumVersion" in the plugin's manifest to "6.9" or higher.`,
+			);
+		});
+
+		it("getSecrets", async () => {
+			// Arrange, act (Command).
+			jest.spyOn(manifest, "getSDKVersion").mockReturnValue(3);
+			jest.spyOn(manifest, "getSoftwareMinimumVersion").mockReturnValue(new Version("6.9"));
+
+			const secrets = getSecrets<Secrets>();
+
+			// Assert (Command).
+			expect(connection.send).toHaveBeenCalledTimes(1);
+			expect(connection.send).toHaveBeenLastCalledWith({
+				event: "getSecrets",
+				context: connection.registrationParameters.pluginUUID,
+			});
+
+			expect(Promise.race([secrets, false])).resolves.toBe(false);
+
+			// Act (Event).
+			connection.emit("didReceiveSecrets", {
+				event: "didReceiveSecrets",
+				payload: {
+					secrets: {
+						secret: "Elgato",
+					},
 				},
-			},
-		});
-		await secrets;
+			});
+			await secrets;
 
-		// Assert (Event).
-		expect(secrets).resolves.toEqual<Secrets>({
-			secret: "Elgato",
+			// Assert (Event).
+			expect(secrets).resolves.toEqual<Secrets>({
+				secret: "Elgato",
+			});
 		});
 	});
 });

--- a/src/plugin/manifest.ts
+++ b/src/plugin/manifest.ts
@@ -36,6 +36,14 @@ const softwareMinimumVersion = new Lazy<Version | null>(() => {
 });
 
 /**
+ * Gets the SDK version that the plugin requires.
+ * @returns SDK version; otherwise `null` when the plugin is DRM protected.
+ */
+export function getSDKVersion(): number | null {
+	return manifest.value?.SDKVersion ?? null;
+}
+
+/**
  * Gets the minimum version that the plugin requires.
  * @returns Minimum required version; otherwise `null` when the plugin is DRM protected.
  */

--- a/src/plugin/system.ts
+++ b/src/plugin/system.ts
@@ -11,7 +11,7 @@ import {
 	Event,
 	SystemDidWakeUpEvent,
 } from "./events";
-import { requiresVersion } from "./validation";
+import { requiresSDKVersion, requiresVersion } from "./validation";
 
 /**
  * Occurs when a monitored application is launched. Monitored applications can be defined in the manifest via the {@link Manifest.ApplicationsToMonitor} property.
@@ -72,6 +72,9 @@ export function openUrl(url: string): Promise<void> {
  * @returns `Promise` resolved with the secrets associated with the plugin.
  */
 export function getSecrets<T extends JsonObject = JsonObject>(): Promise<T> {
+	requiresVersion(6.9, connection.version, "Secrets");
+	requiresSDKVersion(3, "Secrets");
+
 	return new Promise((resolve) => {
 		connection.once("didReceiveSecrets", (ev: DidReceiveSecrets<T>) => resolve(ev.payload.secrets));
 		connection.send({

--- a/src/plugin/validation.ts
+++ b/src/plugin/validation.ts
@@ -1,5 +1,20 @@
 import { Version } from "./common/version";
-import { getSoftwareMinimumVersion } from "./manifest";
+import { getSDKVersion, getSoftwareMinimumVersion } from "./manifest";
+
+/**
+ * Validates the `SDKVersion` within the manifest fulfils the minimum required version for the specified
+ * feature; when the version is not fulfilled, an error is thrown with the feature formatted into the message.
+ * @param minimumVersion Minimum required SDKVersion.
+ * @param feature Feature that requires the version.
+ */
+export function requiresSDKVersion(minimumVersion: number, feature: string): never | void {
+	const sdkVersion = getSDKVersion();
+	if (sdkVersion !== null && minimumVersion > sdkVersion) {
+		throw new Error(
+			`[ERR_NOT_SUPPORTED]: ${feature} requires manifest SDK version ${minimumVersion} or higher, but found version ${sdkVersion}; please update the "SDKVersion" in the plugin's manifest to ${minimumVersion} or higher.`,
+		);
+	}
+}
 
 /**
  * Validates the {@link streamDeckVersion} and manifest's `Software.MinimumVersion` are at least the {@link minimumVersion};


### PR DESCRIPTION
- Adds `SDKVersion` and `Software.MinimumVersion` checks when using the secrets API.
- Adds missing `DidReceiveSecrets` event from API types.