### PR TITLE
fix: Key- & DialAction type guards dropping <T>

### DIFF
--- a/src/plugin/actions/action.ts
+++ b/src/plugin/actions/action.ts
@@ -50,7 +50,7 @@ export class Action<T extends JsonObject = JsonObject> extends ActionContext {
 	 * Determines whether this instance is a dial.
 	 * @returns `true` when this instance is a dial; otherwise `false`.
 	 */
-	public isDial(): this is DialAction {
+	public isDial(): this is DialAction<T> {
 		return this.controllerType === "Encoder";
 	}
 
@@ -58,7 +58,7 @@ export class Action<T extends JsonObject = JsonObject> extends ActionContext {
 	 * Determines whether this instance is a key.
 	 * @returns `true` when this instance is a key; otherwise `false`.
 	 */
-	public isKey(): this is KeyAction {
+	public isKey(): this is KeyAction<T> {
 		return this.controllerType === "Keypad";
 	}
 

--- a/src/plugin/events/ui-message-event.ts
+++ b/src/plugin/events/ui-message-event.ts
@@ -1,7 +1,8 @@
 import type { JsonObject, JsonValue } from "@elgato/utils";
 
 import type { DidReceivePropertyInspectorMessage } from "../../api/index.js";
-import type { Action } from "../actions/action.js";
+import type { DialAction } from "../actions/dial.js";
+import type { KeyAction } from "../actions/key.js";
 import { Event } from "./event.js";
 
 /**
@@ -21,7 +22,7 @@ export class SendToPluginEvent<TPayload extends JsonValue, TSettings extends Jso
 	 * @param source Source of the event, i.e. the original message from Stream Deck.
 	 */
 	constructor(
-		public readonly action: Action<TSettings>,
+		public readonly action: DialAction<TSettings> | KeyAction<TSettings>,
 		source: DidReceivePropertyInspectorMessage<TPayload>,
 	) {
 		super(source);


### PR DESCRIPTION
`Action.isKey()` and `Action.isDial()` could incorrectly narrow `Action<T>` to `KeyAction<JsonObject>` / `DialAction<JsonObject>`.

The issue only surfaced in `onSendToPlugin`, which used `Action<T>`. Other Event types used unions of the `Action` subclasses, which preserved `<T>` during narrowing and thereby shadowed the underlying issue.

The root cause was non-generic type predicates causing a fallback to the default type when narrowing non-union `Action<T>`.

The type guards were updated to preserve `<T>`, and the union-based event types were replaced with `Action<T>`.