### PR TITLE
Fix: getGlobalSettings accumulates orphaned listeners under concurrent or interleaved calls

### DIFF
--- a/src/plugin/settings.ts
+++ b/src/plugin/settings.ts
@@ -1,4 +1,4 @@
-import type { IDisposable, JsonObject } from "@elgato/utils";
+import type { IDisposable, JsonObject, withResolvers } from "@elgato/utils";
 import { randomUUID } from "node:crypto";
 
 import type { DidReceiveGlobalSettings, DidReceiveSettings } from "../api/index.js";
@@ -41,14 +41,29 @@ export const settings = {
 	 * @returns Promise containing the plugin's global settings.
 	 */
 	getGlobalSettings: <T extends JsonObject = JsonObject>(): Promise<T> => {
-		return new Promise((resolve) => {
-			connection.once("didReceiveGlobalSettings", (ev: DidReceiveGlobalSettings<T>) => resolve(ev.payload.settings));
-			connection.send({
-				event: "getGlobalSettings",
-				context: connection.registrationParameters.pluginUUID,
-				id: randomUUID(),
-			});
-		});
+	  const id = randomUUID();
+	  const { promise, resolve, reject } = withResolvers<T>();
+	
+	  const timeoutId = setTimeout(() => {
+	    listener.dispose();
+	    reject(new Error("getGlobalSettings timed out"));
+	  }, REQUEST_TIMEOUT);
+	
+	  const listener = connection.disposableOn("didReceiveGlobalSettings", (ev: DidReceiveGlobalSettings<T>): void => {
+	    if (ev.id === id) {
+	      clearTimeout(timeoutId);
+	      listener.dispose();
+	      resolve(ev.payload.settings);
+	    }
+	  });
+	
+	  connection.send({
+	    event: "getGlobalSettings",
+	    context: connection.registrationParameters.pluginUUID,
+	    id,
+	  });
+	
+	  return promise;
 	},
 
 	/**

--- a/src/plugin/settings.ts
+++ b/src/plugin/settings.ts
@@ -1,4 +1,5 @@
-import type { IDisposable, JsonObject, withResolvers } from "@elgato/utils";
+import type { IDisposable, JsonObject } from "@elgato/utils";
+import { withResolvers } from "@elgato/utils";
 import { randomUUID } from "node:crypto";
 
 import type { DidReceiveGlobalSettings, DidReceiveSettings } from "../api/index.js";
@@ -7,6 +8,8 @@ import { connection } from "./connection.js";
 import { ActionEvent } from "./events/action-event.js";
 import { DidReceiveGlobalSettingsEvent, type DidReceiveSettingsEvent } from "./events/index.js";
 import { requiresVersion } from "./validation.js";
+
+const REQUEST_TIMEOUT = 15 * 1000; // 15s
 
 let __useExperimentalMessageIdentifiers = false;
 
@@ -41,29 +44,29 @@ export const settings = {
 	 * @returns Promise containing the plugin's global settings.
 	 */
 	getGlobalSettings: <T extends JsonObject = JsonObject>(): Promise<T> => {
-	  const id = randomUUID();
-	  const { promise, resolve, reject } = withResolvers<T>();
+		const id = randomUUID();
+		const { promise, resolve, reject } = withResolvers<T>();
 	
-	  const timeoutId = setTimeout(() => {
-	    listener.dispose();
-	    reject(new Error("getGlobalSettings timed out"));
-	  }, REQUEST_TIMEOUT);
+		const timeoutId = setTimeout(() => {
+			listener.dispose();
+			reject(new Error("getGlobalSettings timed out"));
+		}, REQUEST_TIMEOUT);
 	
-	  const listener = connection.disposableOn("didReceiveGlobalSettings", (ev: DidReceiveGlobalSettings<T>): void => {
-	    if (ev.id === id) {
-	      clearTimeout(timeoutId);
-	      listener.dispose();
-	      resolve(ev.payload.settings);
-	    }
-	  });
+		const listener = connection.disposableOn("didReceiveGlobalSettings", (ev: DidReceiveGlobalSettings<T>): void => {
+			if (ev.id === id) {
+				clearTimeout(timeoutId);
+				listener.dispose();
+	    		resolve(ev.payload.settings);
+	    	}
+		});
 	
-	  connection.send({
-	    event: "getGlobalSettings",
-	    context: connection.registrationParameters.pluginUUID,
-	    id,
-	  });
+		connection.send({
+			event: "getGlobalSettings",
+			context: connection.registrationParameters.pluginUUID,
+			id,
+		});
 	
-	  return promise;
+		return promise;
 	},
 
 	/**


### PR DESCRIPTION
getGlobalSettings() currently uses connection.once() with no id filtering and no timeout. If a didReceiveGlobalSettings event arrives from an unrelated trigger (e.g., the property inspector) while a getGlobalSettings() promise is pending, the wrong event resolves the promise and the listener registered for the actual response is permanently orphaned. Under repeated calls this silently accumulates listeners.

This PR aligns getGlobalSettings() with the pattern already used by Action#fetch(): match by request id, use connection.disposableOn() for safe cleanup, and add a timeout to prevent indefinite awaiting. The DidReceiveGlobalSettings type already carries an optional id field for this purpose.