### PR TITLE
fix: terminate process when WebSocket connection to Stream Deck closes

### DIFF
--- a/packages/plugin/src/plugin/__tests__/connection.test.ts
+++ b/packages/plugin/src/plugin/__tests__/connection.test.ts
@@ -34,6 +34,11 @@ describe("connection", () => {
 
 		({ connection } = await import("../connection.js"));
 		process.argv = [...port, ...pluginUUID, ...registerEvent, ...info];
+
+		// @ts-expect-error: prevent process.exit() from exiting
+		vi.spyOn(process, "exit").mockImplementation(() => {
+			/* no-op */
+		});
 	});
 
 	// Reset modules to purge the state.

--- a/packages/plugin/src/plugin/connection.ts
+++ b/packages/plugin/src/plugin/connection.ts
@@ -74,6 +74,7 @@ class Connection extends EventEmitter<ExtendedEventMap> {
 				this.connection.resolve(webSocket);
 				this.emit("connected", this.registrationParameters.info);
 			};
+			webSocket.onclose = (): void => process.exit();
 		}
 
 		await this.connection.promise;


### PR DESCRIPTION
Hello!

This PR contains a simple patch to terminate the plugin process when the WebSocket connection to Stream Deck closes. This ensures that if Stream Deck wasn't able to terminate the plugin process cleanly on exit (e.g. due to Stream Deck being SIGKILLed), it will terminate itself automatically when the WebSocket server is no longer reachable.

Thanks :)